### PR TITLE
Remove OneLogin access token caching logic as you can't do this with …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,5 @@ local.properties
 
 # Project specific
 cms-local-overrides.conf
+/one_login_mfa_api_tester.sh
+/cms_login_tester.sh


### PR DESCRIPTION
…an app in a cluster, as everytime you make a new token it invalidates the older token and an app can only ever have one token.