### PR TITLE
Allow iam roles to be admins

### DIFF
--- a/gradle/develop.gradle
+++ b/gradle/develop.gradle
@@ -215,6 +215,9 @@ embeddedMysql {
     password = flyway.password
 }
 
+/**
+ * Bootstraps some test data into CMS and Vault
+ */
 task bootstrapData() {
     group 'local development'
     description 'Uses the CMS API to inject some data into the in mem data stores, assumes CMS, Vault and' +
@@ -309,25 +312,34 @@ task bootstrapData() {
                         ]
                 ]
         ].each { sdb ->
-            cms.post([
-                    path: '/v1/safe-deposit-box',
-                    body: sdb,
+            try {
+                cms.post([
+                        path   : '/v1/safe-deposit-box',
+                        body   : sdb,
+                        headers: [
+                                'X-Vault-Token': rootToken
+                        ]
+                ])
+            } catch (Exception e) {
+                logger.error("Failure POST /v1/safe-deposit-box, ${sdb.name}, ${e.message}")
+            }
+            try {
+                def slug = sdb.name.replace(' ', '-').toLowerCase()
+                vault.post([
+                    path: "/v1/secret/app/${slug}/config",
+                    body: [
+                            admin_read_token: rootToken,
+                            foo: 'bar',
+                            secret: 'Sup3rS3cr3t'
+                    ],
                     headers: [
-                            'X-Vault-Token': rootToken
+                            'X-Vault-Token': rootToken,
+                            'Content-Type': 'application/json'
                     ]
-            ])
-            vault.post([
-                path: "/secret/${catIdToStringMap."$sdb.category_id"}/config",
-                body: [
-                        admin_read_token: rootToken,
-                        foo: 'bar',
-                        secret: 'Sup3rS3cr3t'
-                ],
-                headers: [
-                        'X-Vault-Token': rootToken,
-                        'Content-Type': 'application/json'
-                ]
-            ])
+                ])
+            } catch (Exception e) {
+                logger.error("Failure POST /secret/app/${slug}/config, ${sdb.name}, ${e.message}")
+            }
         }
     }
 }

--- a/src/main/java/com/nike/cerberus/security/VaultAuthPrincipal.java
+++ b/src/main/java/com/nike/cerberus/security/VaultAuthPrincipal.java
@@ -66,11 +66,7 @@ public class VaultAuthPrincipal implements Principal {
         final ImmutableSet.Builder<String> roleSetBuilder = ImmutableSet.builder();
         final Map<String, String> meta = clientToken.getMeta();
 
-        if (meta == null || meta.isEmpty()) {
-            throw new IllegalArgumentException("client token does not contain expected metadata!");
-        }
-
-        if (Boolean.valueOf(meta.get(METADATA_KEY_IS_ADMIN))) {
+        if (meta != null && Boolean.valueOf(meta.get(METADATA_KEY_IS_ADMIN))) {
             roleSetBuilder.add(ROLE_ADMIN);
         }
 
@@ -81,7 +77,7 @@ public class VaultAuthPrincipal implements Principal {
 
     private Set<String> extractUserGroups(final VaultClientTokenResponse clientToken) {
         final Map<String, String> meta = clientToken.getMeta();
-        final String groupString = meta.get(METADATA_KEY_GROUPS);
+        final String groupString = meta == null ? "" : meta.get(METADATA_KEY_GROUPS);
         if (StringUtils.isBlank(groupString)) {
             return Collections.emptySet();
         } else {
@@ -91,7 +87,7 @@ public class VaultAuthPrincipal implements Principal {
 
     private String extractUsername(final VaultClientTokenResponse clientToken) {
         final Map<String, String> meta = clientToken.getMeta();
-        return meta.get(METADATA_KEY_USERNAME);
+        return meta == null ? "not-set-possibly-root-token" : meta.get(METADATA_KEY_USERNAME);
     }
 
     @Override

--- a/src/main/java/com/nike/cerberus/security/VaultAuthPrincipal.java
+++ b/src/main/java/com/nike/cerberus/security/VaultAuthPrincipal.java
@@ -87,7 +87,9 @@ public class VaultAuthPrincipal implements Principal {
 
     private String extractUsername(final VaultClientTokenResponse clientToken) {
         final Map<String, String> meta = clientToken.getMeta();
-        return meta == null ? "not-set-possibly-root-token" : meta.get(METADATA_KEY_USERNAME);
+        // if a Token that is the root token or created outside of CMS,
+        // then meta might be null and there will be no username set
+        return meta == null ? "unknown-user-manually-created-token" : meta.get(METADATA_KEY_USERNAME);
     }
 
     @Override

--- a/src/main/java/com/nike/cerberus/service/AuthenticationService.java
+++ b/src/main/java/com/nike/cerberus/service/AuthenticationService.java
@@ -412,7 +412,9 @@ public class AuthenticationService {
             if (StringUtils.isNotBlank(adminRoleArns)) {
                 String[] roles = adminRoleArns.split(",");
                 if (roles.length > 0) {
-                    Arrays.stream(roles).forEach(adminRoleArnSet::add);
+                    Arrays.stream(roles).forEach(role -> {
+                        adminRoleArnSet.add(role.trim());
+                    });
                 }
             }
         }

--- a/src/main/java/com/nike/cerberus/service/AuthenticationService.java
+++ b/src/main/java/com/nike/cerberus/service/AuthenticationService.java
@@ -17,6 +17,7 @@
 package com.nike.cerberus.service;
 
 import com.amazonaws.AmazonClientException;
+import com.amazonaws.AmazonServiceException;
 import com.amazonaws.regions.Region;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.kms.AWSKMSClient;
@@ -58,6 +59,8 @@ import org.apache.http.HttpStatus;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -70,15 +73,11 @@ import java.util.Set;
 public class AuthenticationService {
 
     public static final String SYSTEM_USER = "system";
-
     public static final String ADMIN_GROUP_PROPERTY = "cms.admin.group";
-
+    public static final String ADMIN_IAM_ROLES_PROPERTY = "cms.admin.roles";
     public static final String USER_TOKEN_TTL_OVERRIDE = "cms.user.token.ttl.override";
-
     public static final String IAM_TOKEN_TTL_OVERRIDE = "cms.iam.token.ttl.override";
-
     public static final String LOOKUP_SELF_POLICY = "lookup-self";
-
     public static final String DEFAULT_TOKEN_TTL = "1h";
 
     private final SafeDepositBoxDao safeDepositBoxDao;
@@ -91,6 +90,12 @@ public class AuthenticationService {
     private final ObjectMapper objectMapper;
     private final String adminGroup;
     private final DateTimeSupplier dateTimeSupplier;
+
+    @Inject(optional=true)
+    @Named(ADMIN_IAM_ROLES_PROPERTY)
+    String adminRoleArns;
+
+    private Set<String> adminRoleArnSet;
 
     @Inject(optional=true)
     @Named(USER_TOKEN_TTL_OVERRIDE)
@@ -111,6 +116,7 @@ public class AuthenticationService {
                                  final ObjectMapper objectMapper,
                                  @Named(ADMIN_GROUP_PROPERTY) final String adminGroup,
                                  final DateTimeSupplier dateTimeSupplier) {
+
         this.safeDepositBoxDao = safeDepositBoxDao;
         this.awsIamRoleDao = awsIamRoleDao;
         this.authServiceConnector = authConnector;
@@ -171,20 +177,32 @@ public class AuthenticationService {
         final String keyId;
         try {
             keyId = getKeyId(credentials);
-        } catch (InvalidArnException e) {
-            throw ApiException.newBuilder()
-                    .withApiErrors(DefaultApiError.AUTH_IAM_ROLE_REJECTED)
-                    .withExceptionCause(e)
-                    .withExceptionMessage("Failed to lazily provision KMS key for arn:aws:iam::%s:role/%s in region: %s")
-                    .build();
+        } catch (AmazonServiceException e) {
+            if (("InvalidArnException").equals(e.getErrorCode())) {
+                throw ApiException.newBuilder()
+                        .withApiErrors(DefaultApiError.AUTH_IAM_ROLE_REJECTED)
+                        .withExceptionCause(e)
+                        .withExceptionMessage(String.format(
+                                "Failed to lazily provision KMS key for arn:aws:iam::%s:role/%s in region: %s",
+                                credentials.getAccountId(), credentials.getRoleName(), credentials.getRegion()))
+                        .build();
+            }
+            throw e;
         }
 
         final Set<String> policies = buildPolicySet(credentials.getAccountId(), credentials.getRoleName());
+        String arn = String.format("arn:aws:iam::%s:role/%s", credentials.getAccountId(), credentials.getRoleName());
 
         final Map<String, String> meta = Maps.newHashMap();
         meta.put(VaultAuthPrincipal.METADATA_KEY_AWS_ACCOUNT_ID, credentials.getAccountId());
         meta.put(VaultAuthPrincipal.METADATA_KEY_AWS_IAM_ROLE_NAME, credentials.getRoleName());
         meta.put(VaultAuthPrincipal.METADATA_KEY_AWS_REGION, credentials.getRegion());
+        meta.put(VaultAuthPrincipal.METADATA_KEY_USERNAME, arn);
+
+        // We will allow specific ARNs access to the user portions of the API
+        if (getAdminRoleArnSet().contains(arn)) {
+            meta.put(VaultAuthPrincipal.METADATA_KEY_IS_ADMIN, Boolean.toString(true));
+        }
 
         final VaultTokenAuthRequest tokenAuthRequest = new VaultTokenAuthRequest()
                 .setPolicies(policies)
@@ -386,5 +404,18 @@ public class AuthenticationService {
                             String.format("Unexpected error communicating with AWS KMS for region %s.", regionName))
                     .build();
         }
+    }
+
+    private Set<String> getAdminRoleArnSet() {
+        if (adminRoleArnSet == null) {
+            adminRoleArnSet = new HashSet<>();
+            if (StringUtils.isNotBlank(adminRoleArns)) {
+                String[] roles = adminRoleArns.split(",");
+                if (roles.length > 0) {
+                    Arrays.stream(roles).forEach(adminRoleArnSet::add);
+                }
+            }
+        }
+        return adminRoleArnSet;
     }
 }

--- a/src/main/java/com/nike/cerberus/service/AuthenticationService.java
+++ b/src/main/java/com/nike/cerberus/service/AuthenticationService.java
@@ -178,7 +178,7 @@ public class AuthenticationService {
         try {
             keyId = getKeyId(credentials);
         } catch (AmazonServiceException e) {
-            if (("InvalidArnException").equals(e.getErrorCode())) {
+            if ("InvalidArnException".equals(e.getErrorCode())) {
                 throw ApiException.newBuilder()
                         .withApiErrors(DefaultApiError.AUTH_IAM_ROLE_REJECTED)
                         .withExceptionCause(e)


### PR DESCRIPTION
Add code so that CMS can be configured to allow instances to have admin rights.
This is needed to enable the the cross region backup lambda to have access to the metadata admin endpoint.