### PR TITLE
Validate KMS policies at IAM authentication time and recreate polcies…

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -23,7 +23,7 @@ def riposteVersion = '0.8.1'
 def logbackVersion = '1.1.7'
 // Request version 4 for full java 8 support
 def guiceVersion = '4.0'
-def awsSdkVersion = '1.10.54'
+def awsSdkVersion = '1.11.108'
 def groovyVersion = '2.3.9'
 
 dependencies {

--- a/src/main/java/com/nike/cerberus/error/DefaultApiError.java
+++ b/src/main/java/com/nike/cerberus/error/DefaultApiError.java
@@ -193,6 +193,11 @@ public enum DefaultApiError implements ApiError {
     INVALID_QUERY_PARAMS(99224, "Invalid query params", HttpServletResponse.SC_BAD_REQUEST),
 
     /**
+     * Failed to validate that the KMS key policy was valid
+     */
+    FAILED_TO_VALIDATE_KMS_KEY_POLICY(99225, "Failed to validate KMS key policy", HttpServletResponse.SC_INTERNAL_SERVER_ERROR),
+
+    /**
      * Generic not found error.
      */
     ENTITY_NOT_FOUND(99996, "Not found", HttpServletResponse.SC_NOT_FOUND),

--- a/src/main/java/com/nike/cerberus/service/AuthenticationService.java
+++ b/src/main/java/com/nike/cerberus/service/AuthenticationService.java
@@ -366,6 +366,9 @@ public class AuthenticationService {
                     credentials.getRegion(), SYSTEM_USER, dateTimeSupplier.get());
         } else {
             kmsKeyId = kmsKey.get().getAwsKmsKeyId();
+            String iamRoleArn = String.format(AWS_IAM_ROLE_ARN_TEMPLATE, credentials.getAccountId(), credentials.getRoleName());
+            String keyRegion = credentials.getRegion();
+            kmsService.validatePolicy(kmsKeyId, iamRoleArn, keyRegion);
         }
 
         return kmsKeyId;

--- a/src/main/java/com/nike/cerberus/service/KmsService.java
+++ b/src/main/java/com/nike/cerberus/service/KmsService.java
@@ -32,6 +32,8 @@ import com.nike.cerberus.error.DefaultApiError;
 import com.nike.cerberus.record.AwsIamRoleKmsKeyRecord;
 import com.nike.cerberus.util.UuidSupplier;
 import org.mybatis.guice.transactional.Transactional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -42,6 +44,8 @@ import java.time.OffsetDateTime;
  */
 @Singleton
 public class KmsService {
+
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     private static final String KMS_ALIAS_FORMAT = "alias/cerberus/%s";
 
@@ -145,6 +149,8 @@ public class KmsService {
         }
 
         if (! kmsPolicyService.isPolicyValid(policyResult.getPolicy(), iamRoleArn)) {
+            logger.info("The KMS key: {} generated for IAM Role: {} contained an invalid policy, regenerating",
+                    keyId, iamRoleArn);
             String updatedPolicy = kmsPolicyService.generateStandardKmsPolicy(iamRoleArn);
             kmsClient.putKeyPolicy(new PutKeyPolicyRequest()
                     .withKeyId(keyId)

--- a/src/main/java/com/nike/cerberus/service/KmsService.java
+++ b/src/main/java/com/nike/cerberus/service/KmsService.java
@@ -16,13 +16,19 @@
 
 package com.nike.cerberus.service;
 
+import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.kms.AWSKMSClient;
 import com.amazonaws.services.kms.model.CreateAliasRequest;
 import com.amazonaws.services.kms.model.CreateKeyRequest;
 import com.amazonaws.services.kms.model.CreateKeyResult;
+import com.amazonaws.services.kms.model.GetKeyPolicyRequest;
+import com.amazonaws.services.kms.model.GetKeyPolicyResult;
 import com.amazonaws.services.kms.model.KeyUsageType;
+import com.amazonaws.services.kms.model.PutKeyPolicyRequest;
+import com.nike.backstopper.exception.ApiException;
 import com.nike.cerberus.aws.KmsClientFactory;
 import com.nike.cerberus.dao.AwsIamRoleDao;
+import com.nike.cerberus.error.DefaultApiError;
 import com.nike.cerberus.record.AwsIamRoleKmsKeyRecord;
 import com.nike.cerberus.util.UuidSupplier;
 import org.mybatis.guice.transactional.Transactional;
@@ -104,5 +110,47 @@ public class KmsService {
         awsIamRoleDao.createIamRoleKmsKey(awsIamRoleKmsKeyRecord);
 
         return result.getKeyMetadata().getArn();
+    }
+
+    /**
+     * When a KMS key policy statement is created and an AWS ARN is specified as a principal,
+     * AWS behind the scene binds that ARNs ID to the statement and not the ARN.
+     *
+     * They do this so that when a role or user is deleted and another team or person recreates the identity
+     * that this new identity does not get permissions that were not meant for it.
+     *
+     * In Cerberus's case we need to support a flow where teams use automation to automatically destroy and recreate IAM roles.
+     *
+     * We can detect that this event has happened because when an Identity that was referenced by an ARN in a KMS policy
+     * statement has been deleted the ARN is replaced by the ID. We can validate that principal matches an ARN pattern
+     * or recreate the policy.
+     *
+     * @param keyId - The CMK Id to validate the policies on.
+     * @param iamRoleArn - The Role ARN that should have decrypt permission
+     * @param kmsCMKRegion - The region that the key was provisioned for
+     */
+    public void validatePolicy(String keyId, String iamRoleArn, String kmsCMKRegion) {
+        AWSKMSClient kmsClient = kmsClientFactory.getClient(kmsCMKRegion);
+        GetKeyPolicyResult policyResult = null;
+        try {
+            policyResult = kmsClient.getKeyPolicy(new GetKeyPolicyRequest().withKeyId(keyId).withPolicyName("default"));
+        } catch (AmazonServiceException e) {
+            throw ApiException.newBuilder()
+                    .withApiErrors(DefaultApiError.FAILED_TO_VALIDATE_KMS_KEY_POLICY)
+                    .withExceptionCause(e)
+                    .withExceptionMessage(
+                            String.format("Failed to validate KMS key policy for keyId: " +
+                                    "%s for IAM role: %s in region: %s", keyId, iamRoleArn, kmsCMKRegion))
+                    .build();
+        }
+
+        if (! kmsPolicyService.isPolicyValid(policyResult.getPolicy(), iamRoleArn)) {
+            String updatedPolicy = kmsPolicyService.generateStandardKmsPolicy(iamRoleArn);
+            kmsClient.putKeyPolicy(new PutKeyPolicyRequest()
+                    .withKeyId(keyId)
+                    .withPolicyName("default")
+                    .withPolicy(updatedPolicy)
+            );
+        }
     }
 }

--- a/src/test/java/com/nike/cerberus/service/KmsPolicyServiceTest.java
+++ b/src/test/java/com/nike/cerberus/service/KmsPolicyServiceTest.java
@@ -1,5 +1,7 @@
 package com.nike.cerberus.service;
 
+import com.amazonaws.auth.policy.Policy;
+import com.amazonaws.auth.policy.Statement;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.IOUtils;
@@ -69,6 +71,11 @@ public class KmsPolicyServiceTest {
         String policyJsonAsString = IOUtils.toString(policy, "UTF-8");
 
         assertFalse(kmsPolicyService.isPolicyValid(policyJsonAsString, CERBERUS_CONSUMER_IAM_ROLE_ARN));
+    }
+
+    @Test
+    public void test_that_generateStandardKmsPolicy_returns_false_when_a_non_standard_policy_is_supplied() {
+        assertFalse(kmsPolicyService.isPolicyValid(null, CERBERUS_CONSUMER_IAM_ROLE_ARN));
     }
 
 }

--- a/src/test/resources/com/nike/cerberus/service/invalid-cerberus-iam-auth-kms-key-policy.json
+++ b/src/test/resources/com/nike/cerberus/service/invalid-cerberus-iam-auth-kms-key-policy.json
@@ -1,0 +1,61 @@
+{
+  "Version":"2012-10-17",
+  "Statement":[
+    {
+      "Sid":"Root User Has All Actions",
+      "Effect":"Allow",
+      "Principal":{
+        "AWS":"arn:aws:iam::1111111111:root"
+      },
+      "Action":[
+        "kms:*"
+      ],
+      "Resource":[
+        "*"
+      ]
+    },
+    {
+      "Sid":"Admin Role Has All Actions",
+      "Effect":"Allow",
+      "Principal":{
+        "AWS":"arn:aws:iam::1111111111:role/admin"
+      },
+      "Action":[
+        "kms:*"
+      ],
+      "Resource":[
+        "*"
+      ]
+    },
+    {
+      "Sid":"CMS Role Key Access",
+      "Effect":"Allow",
+      "Principal":{
+        "AWS":"arn:aws:iam::1111111111:role/cms-iam-role"
+      },
+      "Action":[
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey"
+      ],
+      "Resource":[
+        "*"
+      ]
+    },
+    {
+      "Sid":"Target IAM Role Has Decrypt Action",
+      "Effect":"Allow",
+      "Principal":{
+        "AWS":"AROAIXRUWWN44IQRY7KYM"
+      },
+      "Action":[
+        "kms:Decrypt"
+      ],
+      "Resource":[
+        "*"
+      ]
+    }
+  ]
+}

--- a/src/test/resources/com/nike/cerberus/service/valid-cerberus-iam-auth-kms-key-policy.json
+++ b/src/test/resources/com/nike/cerberus/service/valid-cerberus-iam-auth-kms-key-policy.json
@@ -1,0 +1,61 @@
+{
+  "Version":"2012-10-17",
+  "Statement":[
+    {
+      "Sid":"Root User Has All Actions",
+      "Effect":"Allow",
+      "Principal":{
+        "AWS":"arn:aws:iam::1111111111:root"
+      },
+      "Action":[
+        "kms:*"
+      ],
+      "Resource":[
+        "*"
+      ]
+    },
+    {
+      "Sid":"Admin Role Has All Actions",
+      "Effect":"Allow",
+      "Principal":{
+        "AWS":"arn:aws:iam::1111111111:role/admin"
+      },
+      "Action":[
+        "kms:*"
+      ],
+      "Resource":[
+        "*"
+      ]
+    },
+    {
+      "Sid":"CMS Role Key Access",
+      "Effect":"Allow",
+      "Principal":{
+        "AWS":"arn:aws:iam::1111111111:role/cms-iam-role"
+      },
+      "Action":[
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey"
+      ],
+      "Resource":[
+        "*"
+      ]
+    },
+    {
+      "Sid":"Target IAM Role Has Decrypt Action",
+      "Effect":"Allow",
+      "Principal":{
+        "AWS":"arn:aws:iam::1234567890:role/cerberus-consumer"
+      },
+      "Action":[
+        "kms:Decrypt"
+      ],
+      "Resource":[
+        "*"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
… where a consumer has deleted and recreated an IAM role causing the KMS key policy to reference an ID rather than the user supplied ARN