### PR TITLE
Fix incorrect error codes, and add better messaging

### DIFF
--- a/src/main/java/com/nike/cerberus/auth/connector/onelogin/OneLoginAuthConnector.java
+++ b/src/main/java/com/nike/cerberus/auth/connector/onelogin/OneLoginAuthConnector.java
@@ -194,7 +194,7 @@ public class OneLoginAuthConnector implements AuthConnector {
                         .withApiErrors(DefaultApiError.MFA_SETUP_REQUIRED)
                         .withExceptionMessage(msg)
                         .build();
-            } else if (statusCode == 401) {
+            } else if (statusCode == 400 || statusCode == 401) {
                 throw ApiException.newBuilder()
                         .withApiErrors(DefaultApiError.AUTH_BAD_CREDENTIALS)
                         .withExceptionMessage(msg)

--- a/src/main/java/com/nike/cerberus/auth/connector/onelogin/OneLoginAuthConnector.java
+++ b/src/main/java/com/nike/cerberus/auth/connector/onelogin/OneLoginAuthConnector.java
@@ -194,8 +194,7 @@ public class OneLoginAuthConnector implements AuthConnector {
                         .withApiErrors(DefaultApiError.MFA_SETUP_REQUIRED)
                         .withExceptionMessage(msg)
                         .build();
-            }
-            if (statusCode == 401) {
+            } else if (statusCode == 401) {
                 throw ApiException.newBuilder()
                         .withApiErrors(DefaultApiError.AUTH_BAD_CREDENTIALS)
                         .withExceptionMessage(msg)

--- a/src/main/java/com/nike/cerberus/aws/KmsClientFactory.java
+++ b/src/main/java/com/nike/cerberus/aws/KmsClientFactory.java
@@ -20,6 +20,8 @@ import com.amazonaws.regions.Region;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.kms.AWSKMSClient;
 import com.google.common.collect.Maps;
+import com.nike.backstopper.exception.ApiException;
+import com.nike.cerberus.error.DefaultApiError;
 
 import javax.inject.Singleton;
 import java.util.Map;
@@ -62,7 +64,11 @@ public class KmsClientFactory {
             final Region region = Region.getRegion(Regions.fromName(regionName));
             return getClient(region);
         } catch (IllegalArgumentException iae) {
-            throw new IllegalArgumentException("Specified region is not valid.", iae);
+            throw ApiException.newBuilder()
+                    .withApiErrors(DefaultApiError.AUTHENTICATION_ERROR_INVALID_REGION)
+                    .withExceptionCause(iae.getCause())
+                    .withExceptionMessage("Specified region is not valid.")
+                    .build();
         }
     }
 }

--- a/src/main/java/com/nike/cerberus/error/DefaultApiError.java
+++ b/src/main/java/com/nike/cerberus/error/DefaultApiError.java
@@ -64,7 +64,7 @@ public enum DefaultApiError implements ApiError {
     /**
      * Supplied credentials are invalid.
      */
-    AUTH_BAD_CREDENTIALS(99106, "Invalid credentials", HttpServletResponse.SC_BAD_REQUEST),
+    AUTH_BAD_CREDENTIALS(99106, "Invalid credentials", HttpServletResponse.SC_UNAUTHORIZED),
 
     /**
      * Category display name is blank.

--- a/src/main/java/com/nike/cerberus/error/DefaultApiError.java
+++ b/src/main/java/com/nike/cerberus/error/DefaultApiError.java
@@ -119,7 +119,7 @@ public enum DefaultApiError implements ApiError {
     /**
      * SDB name isn't unique.
      */
-    SDB_UNIQUE_NAME(99210, "The name is not unique.", HttpServletResponse.SC_BAD_REQUEST),
+    SDB_UNIQUE_NAME(99210, "Duplicate SDB names are not allowed.", HttpServletResponse.SC_BAD_REQUEST),
 
     /**
      * SDB action requires caller to be the owner.
@@ -216,6 +216,11 @@ public enum DefaultApiError implements ApiError {
      * IAM Role account id is blank
      */
     AUTH_IAM_PRINCIPAL_AWS_REGION_BLANK(99228, "AWS region is malformed.", HttpServletResponse.SC_BAD_REQUEST),
+
+    /**
+     * Invalid region provided in authentication
+     */
+    AUTHENTICATION_ERROR_INVALID_REGION(99229, "Invalid AWS region provided during authentication.", HttpServletResponse.SC_BAD_REQUEST),
 
     /**
      * Generic not found error.

--- a/src/test/java/com/nike/cerberus/auth/connector/onelogin/OneLoginAuthConnectorTest.java
+++ b/src/test/java/com/nike/cerberus/auth/connector/onelogin/OneLoginAuthConnectorTest.java
@@ -103,7 +103,7 @@ public class OneLoginAuthConnectorTest {
     @Test
     public void test_authenticate_when_mfa_is_not_setup() {
 
-        setupMockWhereLoginGivesError(400L, "mfa something error message");
+        setupMockWhereLoginGivesError(400, "mfa something error message");
 
         try {
             // invoke method under test
@@ -118,7 +118,7 @@ public class OneLoginAuthConnectorTest {
 
     @Test
     public void test_authenticate_with_bad_creds() {
-        setupMockWhereLoginGivesError(400L, "any other error message");
+        setupMockWhereLoginGivesError(401, "any other error message");
 
         try {
             // invoke method under test
@@ -240,7 +240,7 @@ public class OneLoginAuthConnectorTest {
     @Test
     public void test_verifyFactor_with_400_error() {
 
-        setupMockWhereVerifyGivesError(400L, "any error message");
+        setupMockWhereVerifyGivesError(401, "any error message");
 
         try {
             // invoke method under test

--- a/src/test/java/com/nike/cerberus/aws/KmsClientFactoryTest.java
+++ b/src/test/java/com/nike/cerberus/aws/KmsClientFactoryTest.java
@@ -19,6 +19,7 @@ package com.nike.cerberus.aws;
 import com.amazonaws.regions.Region;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.kms.AWSKMSClient;
+import com.nike.backstopper.exception.ApiException;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -56,7 +57,7 @@ public class KmsClientFactoryTest {
         assertThat(client).isNotNull();
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = ApiException.class)
     public void get_client_by_region_string_throws_exception_if_bad_region_passed() {
         subject.getClient(badRegionName);
     }


### PR DESCRIPTION
* Return the proper error codes and messages for:
    * Bad username, password or MFA
    * Invalid region during IAM authentication (Issue #18)
    * Duplicate SDB names