### PR TITLE
fixed bade copy paste code error, where rolename was being put into t…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,6 +14,6 @@
 # limitations under the License.
 #
 
-version=0.18.0
+version=0.18.1
 groupId=com.nike.cerberus
 artifactId=cms

--- a/src/main/java/com/nike/cerberus/service/AuthenticationService.java
+++ b/src/main/java/com/nike/cerberus/service/AuthenticationService.java
@@ -195,7 +195,7 @@ public class AuthenticationService {
         iamPrincipalCredentials.setRegion(region);
 
         final Map<String, String> vaultAuthPrincipalMetadata = generateCommonVaultPrincipalAuthMetadata(iamPrincipalArn, region);
-        vaultAuthPrincipalMetadata.put(VaultAuthPrincipal.METADATA_KEY_AWS_ACCOUNT_ID,awsIamRoleArnParser.getAccountId(iamPrincipalArn));
+        vaultAuthPrincipalMetadata.put(VaultAuthPrincipal.METADATA_KEY_AWS_ACCOUNT_ID, awsIamRoleArnParser.getAccountId(iamPrincipalArn));
         vaultAuthPrincipalMetadata.put(VaultAuthPrincipal.METADATA_KEY_AWS_IAM_ROLE_NAME, awsIamRoleArnParser.getRoleName(iamPrincipalArn));
 
         return authenticate(iamPrincipalCredentials, vaultAuthPrincipalMetadata);
@@ -205,7 +205,7 @@ public class AuthenticationService {
 
         final String iamPrincipalArn = credentials.getIamPrincipalArn();
         final Map<String, String> vaultAuthPrincipalMetadata = generateCommonVaultPrincipalAuthMetadata(iamPrincipalArn, credentials.getRegion());
-        vaultAuthPrincipalMetadata.put(VaultAuthPrincipal.METADATA_KEY_AWS_IAM_PRINCIPAL_ARN, awsIamRoleArnParser.getRoleName(iamPrincipalArn));
+        vaultAuthPrincipalMetadata.put(VaultAuthPrincipal.METADATA_KEY_AWS_IAM_PRINCIPAL_ARN, iamPrincipalArn);
 
         return authenticate(credentials, vaultAuthPrincipalMetadata);
     }


### PR DESCRIPTION
fixed bade copy paste code error, where role name was being put into the token metadata instead of arn, when not all arns are roles

When authenticating as a user against v2 the following error is returned

    {
        "error_id": "624cc9fd35-aad2d-481e-b191-362c88748a05",
        "errors": [
           {
                "code": 99996,
                "message": "The arn arn:aws:iam::11111111111111:user/admin was not a valid arn in 'arn:aws:iam::(.*?):role/(.*)' format"
            }
        ]
    }