### PR TITLE
Enable all principals to authenticate with Cerberus

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,6 +14,6 @@
 # limitations under the License.
 #
 
-version=0.20.0
+version=0.20.2
 groupId=com.nike.cerberus
 artifactId=cms

--- a/src/main/java/com/nike/cerberus/service/AuthenticationService.java
+++ b/src/main/java/com/nike/cerberus/service/AuthenticationService.java
@@ -59,20 +59,20 @@ import com.nike.vault.client.model.VaultTokenAuthRequest;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
-import org.joda.time.Interval;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.time.OffsetDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+
+import static com.nike.cerberus.util.AwsIamRoleArnParser.AWS_IAM_ROLE_ARN_TEMPLATE;
 
 /**
  * Authentication service for Users and IAM roles to be able to authenticate and get an assigned Vault token.
@@ -189,7 +189,7 @@ public class AuthenticationService {
      */
     public IamRoleAuthResponse authenticate(IamRoleCredentials credentials) {
 
-        final String iamPrincipalArn = String.format(AwsIamRoleArnParser.AWS_IAM_ROLE_ARN_TEMPLATE, credentials.getAccountId(),
+        final String iamPrincipalArn = String.format(AWS_IAM_ROLE_ARN_TEMPLATE, credentials.getAccountId(),
                 credentials.getRoleName());
         final String region = credentials.getRegion();
 
@@ -230,7 +230,7 @@ public class AuthenticationService {
             throw e;
         }
 
-        final Set<String> policies = buildPolicySet(credentials.getIamPrincipalArn());
+        final Set<String> policies = buildCompleteSetOfPolicies(credentials.getIamPrincipalArn());
 
         final VaultTokenAuthRequest tokenAuthRequest = new VaultTokenAuthRequest()
                 .setPolicies(policies)
@@ -401,6 +401,25 @@ public class AuthenticationService {
         return policies;
     }
 
+    protected Set<String> buildCompleteSetOfPolicies(final String iamPrincipalArn) {
+
+        final Set<String> allPolicies = buildPolicySet(iamPrincipalArn);
+
+        try {
+            if (! awsIamRoleArnParser.isRoleArn(iamPrincipalArn)) {
+                logger.debug("Could not find IAM role in principal format, trying 'role' format...");
+                final String iamPrincipalInRoleFormat = awsIamRoleArnParser.convertPrincipalArnToRoleArn(iamPrincipalArn);
+
+                final Set<String> additionalPolicies = buildPolicySet(iamPrincipalInRoleFormat);
+                allPolicies.addAll(additionalPolicies);
+            }
+        } catch (Exception e) {
+            logger.debug("Failed to convert principal ARN to role ARN");
+        }
+
+        return allPolicies;
+    }
+
     /**
      * Builds the policy set to be associated with the to-be generated Vault token.  The lookup-self policy is
      * included by default.  All other associated policies are based on what permissions are granted to the IAM role.
@@ -428,29 +447,29 @@ public class AuthenticationService {
      * @return KMS Key id
      */
     protected String getKeyId(IamPrincipalCredentials credentials) {
-        final Optional<AwsIamRoleRecord> iamRole = awsIamRoleDao.getIamRole(credentials.getIamPrincipalArn());
+        final String iamPrincipalArn = credentials.getIamPrincipalArn();
+        final String region = credentials.getRegion();
+        final Optional<AwsIamRoleRecord> iamRole = findIamRoleAssociatedWithSdb(iamPrincipalArn);
 
         if (!iamRole.isPresent()) {
             throw ApiException.newBuilder()
                     .withApiErrors(DefaultApiError.AUTH_IAM_PRINCIPAL_INVALID)
-                    .withExceptionMessage(String.format("The role: %s was not configured for any SDB",
-                            credentials.getIamPrincipalArn()))
+                    .withExceptionMessage(String.format("The role: %s was not configured for any SDB", iamPrincipalArn))
                     .build();
         }
 
-        final Optional<AwsIamRoleKmsKeyRecord> kmsKey = awsIamRoleDao.getKmsKey(iamRole.get().getId(), credentials.getRegion());
+        final Optional<AwsIamRoleKmsKeyRecord> kmsKey = awsIamRoleDao.getKmsKey(iamRole.get().getId(), region);
 
         final String kmsKeyId;
         final AwsIamRoleKmsKeyRecord kmsKeyRecord;
         final OffsetDateTime now = dateTimeSupplier.get();
 
         if (!kmsKey.isPresent()) {
-            kmsKeyId = kmsService.provisionKmsKey(iamRole.get().getId(), credentials.getIamPrincipalArn(),
-                    credentials.getRegion(), SYSTEM_USER, now);
+            kmsKeyId = kmsService.provisionKmsKey(iamRole.get().getId(), iamPrincipalArn, region, SYSTEM_USER, now);
         } else {
             kmsKeyRecord = kmsKey.get();
             kmsKeyId = kmsKeyRecord.getAwsKmsKeyId();
-            kmsService.validatePolicy(kmsKeyRecord, credentials.getIamPrincipalArn());
+            kmsService.validatePolicy(kmsKeyRecord, iamPrincipalArn);
         }
 
         return kmsKeyId;
@@ -507,8 +526,7 @@ public class AuthenticationService {
         return adminRoleArnSet;
     }
 
-    protected Map<String, String> generateCommonVaultPrincipalAuthMetadata(String iamPrincipalArn, String region) {
-
+    protected Map<String, String> generateCommonVaultPrincipalAuthMetadata(final String iamPrincipalArn, final String region) {
         Map<String, String> metadata = Maps.newHashMap();
         metadata.put(VaultAuthPrincipal.METADATA_KEY_AWS_REGION, region);
         metadata.put(VaultAuthPrincipal.METADATA_KEY_USERNAME, iamPrincipalArn);
@@ -526,5 +544,24 @@ public class AuthenticationService {
         metadata.put(VaultAuthPrincipal.METADATA_KEY_GROUPS, StringUtils.join(groups, ','));
 
         return metadata;
+    }
+
+    protected Optional<AwsIamRoleRecord> findIamRoleAssociatedWithSdb(final String iamPrincipalArn) {
+        Optional<AwsIamRoleRecord> iamRole = awsIamRoleDao.getIamRole(iamPrincipalArn);
+
+        try {
+            // if the arn is not already in 'role' format, and cannot be found,
+            // then try checking for the generic "arn:aws:iam::0000000000:role/foo" format
+            if ( !( awsIamRoleArnParser.isRoleArn(iamPrincipalArn) || iamRole.isPresent() ) ) {
+                logger.debug("Could not find IAM role in principal format, trying 'role' format...");
+                final String iamPrincipalInRoleFormat = awsIamRoleArnParser.convertPrincipalArnToRoleArn(iamPrincipalArn);
+
+                iamRole = awsIamRoleDao.getIamRole(iamPrincipalInRoleFormat);
+            }
+        } catch(Exception e) {
+            logger.debug("Failed to convert principal ARN to role ARN");
+        }
+
+        return iamRole;
     }
 }

--- a/src/main/java/com/nike/cerberus/util/AwsIamRoleArnParser.java
+++ b/src/main/java/com/nike/cerberus/util/AwsIamRoleArnParser.java
@@ -19,7 +19,6 @@ package com.nike.cerberus.util;
 
 import com.nike.backstopper.exception.ApiException;
 import com.nike.cerberus.error.InvalidIamRoleArnApiError;
-import org.apache.commons.lang3.StringUtils;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -54,7 +53,7 @@ public class AwsIamRoleArnParser {
      */
     public String getAccountId(final String roleArn) {
 
-        return getNamedGroupFromPattern(IAM_ROLE_ARN_PATTERN, "accountId", roleArn);
+        return getNamedGroupFromRegexPattern(IAM_ROLE_ARN_PATTERN, "accountId", roleArn);
     }
 
     /**
@@ -64,7 +63,7 @@ public class AwsIamRoleArnParser {
      */
     public String getRoleName(final String roleArn) {
 
-        return getNamedGroupFromPattern(IAM_ROLE_ARN_PATTERN, "roleName", roleArn);
+        return getNamedGroupFromRegexPattern(IAM_ROLE_ARN_PATTERN, "roleName", roleArn);
 
     }
 
@@ -81,7 +80,7 @@ public class AwsIamRoleArnParser {
     }
 
     /**
-     * Converts a principal ARN (e.g. 'arn:aws:iam::0000000000:instance-profile/example') to a 'role' ARN,
+     * Converts a principal ARN (e.g. 'arn:aws:iam::0000000000:instance-profile/example') to a role ARN,
      * (i.e. 'arn:aws:iam::000000000:role/example')
      * @param principalArn - Principal ARN to convert
      * @return - Role ARN
@@ -95,13 +94,14 @@ public class AwsIamRoleArnParser {
         final boolean isAssumedRole = GENERIC_ASSUMED_ROLE_PATTERN.matcher(principalArn).find();
         final Pattern patternToMatch = isAssumedRole ? IAM_ASSUMED_ROLE_ARN_PATTERN : IAM_PRINCIPAL_ARN_PATTERN;
 
-        final String accountId = getNamedGroupFromPattern(patternToMatch, "accountId", principalArn);
-        final String roleName = getNamedGroupFromPattern(patternToMatch, "roleName", principalArn);
+        final String accountId = getNamedGroupFromRegexPattern(patternToMatch, "accountId", principalArn);
+        final String roleName = getNamedGroupFromRegexPattern(patternToMatch, "roleName", principalArn);
 
         return String.format(AWS_IAM_ROLE_ARN_TEMPLATE, accountId, roleName);
     }
 
-    private String getNamedGroupFromPattern(final Pattern pattern, final String groupName, final String input) {
+
+    private String getNamedGroupFromRegexPattern(final Pattern pattern, final String groupName, final String input) {
         final Matcher iamRoleArnMatcher = pattern.matcher(input);
 
         if (! iamRoleArnMatcher.find()) {

--- a/src/main/java/com/nike/cerberus/util/AwsIamRoleArnParser.java
+++ b/src/main/java/com/nike/cerberus/util/AwsIamRoleArnParser.java
@@ -31,33 +31,48 @@ public class AwsIamRoleArnParser {
 
     public static final String AWS_IAM_ROLE_ARN_TEMPLATE = "arn:aws:iam::%s:role/%s";
 
-    public static final String AWS_IAM_ROLE_ARN_REGEX = "^arn:aws:iam::(?<accountId>\\d+?):role/(?<roleName>.+)$";
-
     public static final String AWS_IAM_PRINCIPAL_ARN_REGEX = "^arn:aws:(iam|sts)::(?<accountId>\\d+?):(?!group).+?/(?<roleName>.+)$";
 
-    public static final String AWS_IAM_ASSUMED_ROLE_ARN_REGEX = "^arn:aws:sts::(?<accountId>\\d+?):assumed-role/(?<roleName>.+)/.+$";
+    private static final String AWS_IAM_ROLE_ARN_REGEX = "^arn:aws:iam::(?<accountId>\\d+?):role/(?<roleName>.+)$";
+
+    private static final String AWS_IAM_ASSUMED_ROLE_ARN_REGEX = "^arn:aws:sts::(?<accountId>\\d+?):assumed-role/(?<roleName>.+)/.+$";
 
     private static final String GENERIC_ASSUMED_ROLE_REGEX = "^arn:aws:sts::(?<accountId>\\d+?):assumed-role/.+$";
 
-    private static final Pattern IAM_ROLE_ARN_PATTERN = Pattern.compile(AWS_IAM_ROLE_ARN_REGEX);
-
     private static final Pattern IAM_PRINCIPAL_ARN_PATTERN = Pattern.compile(AWS_IAM_PRINCIPAL_ARN_REGEX);
+
+    private static final Pattern IAM_ROLE_ARN_PATTERN = Pattern.compile(AWS_IAM_ROLE_ARN_REGEX);
 
     private static final Pattern IAM_ASSUMED_ROLE_ARN_PATTERN = Pattern.compile(AWS_IAM_ASSUMED_ROLE_ARN_REGEX);
 
     private static final Pattern GENERIC_ASSUMED_ROLE_PATTERN = Pattern.compile(GENERIC_ASSUMED_ROLE_REGEX);
 
+    /**
+     * Gets account ID from a 'role' ARN
+     * @param roleArn - Role ARN to parse
+     * @return - Account ID
+     */
     public String getAccountId(final String roleArn) {
 
         return getNamedGroupFromPattern(IAM_ROLE_ARN_PATTERN, "accountId", roleArn);
     }
 
+    /**
+     * Gets role name form a 'role' ARN
+     * @param roleArn - Role ARN to parse
+     * @return
+     */
     public String getRoleName(final String roleArn) {
 
         return getNamedGroupFromPattern(IAM_ROLE_ARN_PATTERN, "roleName", roleArn);
 
     }
 
+    /**
+     * Returns true if the ARN is in format 'arn:aws:iam::000000000:role/example' and false if not
+     * @param arn - ARN to test
+     * @return - True if is 'role' ARN, False if not
+     */
     public boolean isRoleArn(final String arn) {
 
         final Matcher iamRoleArnMatcher = IAM_ROLE_ARN_PATTERN.matcher(arn);
@@ -65,6 +80,12 @@ public class AwsIamRoleArnParser {
         return iamRoleArnMatcher.find();
     }
 
+    /**
+     * Converts a principal ARN (e.g. 'arn:aws:iam::0000000000:instance-profile/example') to a 'role' ARN,
+     * (i.e. 'arn:aws:iam::000000000:role/example')
+     * @param principalArn - Principal ARN to convert
+     * @return - Role ARN
+     */
     public String convertPrincipalArnToRoleArn(final String principalArn) {
 
         if (isRoleArn(principalArn)) {
@@ -86,6 +107,7 @@ public class AwsIamRoleArnParser {
         if (! iamRoleArnMatcher.find()) {
             throw ApiException.newBuilder()
                     .withApiErrors(new InvalidIamRoleArnApiError(input))
+                    .withExceptionMessage("ARN does not match pattern: " + pattern.toString())
                     .build();
         }
 

--- a/src/test/java/com/nike/cerberus/service/AuthenticationServiceTest.java
+++ b/src/test/java/com/nike/cerberus/service/AuthenticationServiceTest.java
@@ -49,7 +49,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.regex.PatternSyntaxException;
 
 import static com.nike.cerberus.service.AuthenticationService.LOOKUP_SELF_POLICY;
 import static com.nike.cerberus.util.AwsIamRoleArnParser.AWS_IAM_ROLE_ARN_TEMPLATE;
@@ -58,7 +57,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -204,26 +203,6 @@ public class AuthenticationServiceTest {
     }
 
     @Test
-    public void test_that_buildCompleteSetOfPolicies_does_not_throw_error_if_role_arn_parsing_fails() {
-
-        String accountId = "0000000000";
-        String roleName = "role/path";
-        String principalArn = String.format("arn:aws:iam::%s:instance-profile/%s", accountId, roleName);
-
-        when(awsIamRoleArnParser.isRoleArn(principalArn)).thenReturn(false);
-        when(awsIamRoleArnParser.convertPrincipalArnToRoleArn(principalArn)).thenThrow(new NullPointerException());
-
-        String principalPolicy1 = "principal policy";
-        String principalArnSdb1 = "principal arn sdb";
-        SafeDepositBoxRoleRecord principalArnRecord1 = new SafeDepositBoxRoleRecord().setRoleName(roleName).setSafeDepositBoxName(principalArnSdb1);
-        List<SafeDepositBoxRoleRecord> principalArnRecords = Lists.newArrayList(principalArnRecord1);
-        when(safeDepositBoxDao.getIamRoleAssociatedSafeDepositBoxRoles(principalArn)).thenReturn(principalArnRecords);
-        when(vaultPolicyService.buildPolicyName(principalArnSdb1, roleName)).thenReturn(principalPolicy1);
-
-        authenticationService.buildCompleteSetOfPolicies(principalArn);
-    }
-
-    @Test
     public void test_that_findIamRoleAssociatedWithSdb_returns_first_matching_iam_role_record_if_found() {
 
         String principalArn = "principal arn";
@@ -272,21 +251,6 @@ public class AuthenticationServiceTest {
         Optional<AwsIamRoleRecord> result = authenticationService.findIamRoleAssociatedWithSdb(principalArn);
 
         assertFalse(result.isPresent());
-    }
-
-    @Test
-    public void test_that_findIamRoleAssociatedWithSdb_does_not_throw_error_if_role_arn_parsing_fails() {
-
-        String accountId = "0000000000";
-        String roleName = "role/path";
-        String principalArn = String.format("arn:aws:iam::%s:instance-profile/%s", accountId, roleName);
-
-        when(awsIamRoleDao.getIamRole(principalArn)).thenReturn(Optional.empty());
-
-        when(awsIamRoleArnParser.isRoleArn(principalArn)).thenReturn(false);
-        when(awsIamRoleArnParser.convertPrincipalArnToRoleArn(principalArn)).thenThrow(new PatternSyntaxException("", "", 0));
-
-        authenticationService.findIamRoleAssociatedWithSdb(principalArn);
     }
 
     @Test

--- a/src/test/java/com/nike/cerberus/util/AwsIamRoleArnParserTest.java
+++ b/src/test/java/com/nike/cerberus/util/AwsIamRoleArnParserTest.java
@@ -25,6 +25,8 @@ import java.util.regex.Pattern;
 
 import static org.junit.Assert.assertEquals;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -63,5 +65,43 @@ public class AwsIamRoleArnParserTest {
     public void getRoleName_fails_on_invalid_arn() {
 
         awsIamRoleArnParser.getRoleName("brouhaha");
+    }
+
+    @Test
+    public void convertPrincipalArnToRoleArn_properly_converts_principals_to_role_arns() {
+
+        assertEquals("arn:aws:iam::1111111111:role/lamb_dev_health", awsIamRoleArnParser.convertPrincipalArnToRoleArn("arn:aws:sts::1111111111:federated-user/lamb_dev_health"));
+        assertEquals("arn:aws:iam::2222222222:role/prince_role", awsIamRoleArnParser.convertPrincipalArnToRoleArn("arn:aws:sts::2222222222:assumed-role/prince_role/session-name"));
+        assertEquals("arn:aws:iam::2222222222:role/sir/alfred/role", awsIamRoleArnParser.convertPrincipalArnToRoleArn("arn:aws:sts::2222222222:assumed-role/sir/alfred/role/session-name"));
+        assertEquals("arn:aws:iam::3333333333:role/path/to/foo", awsIamRoleArnParser.convertPrincipalArnToRoleArn("arn:aws:iam::3333333333:role/path/to/foo"));
+        assertEquals("arn:aws:iam::4444444444:role/name", awsIamRoleArnParser.convertPrincipalArnToRoleArn("arn:aws:iam::4444444444:role/name"));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void convertPrincipalArnToRoleArn_fails_on_invalid_arn() {
+
+        awsIamRoleArnParser.convertPrincipalArnToRoleArn("foobar");
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void convertPrincipalArnToRoleArn_fails_on_group_arn() {
+
+        awsIamRoleArnParser.convertPrincipalArnToRoleArn("arn:aws:iam::1111111111:group/path/to/group");
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void convertPrincipalArnToRoleArn_fails_on_invalid_assumed_role_arn() {
+
+        awsIamRoleArnParser.convertPrincipalArnToRoleArn("arn:aws:sts::1111111111:assumed-role/blah");
+    }
+
+    @Test
+    public void isRoleArn_returns_true_when_is_role_arn()  {
+
+        assertTrue(awsIamRoleArnParser.isRoleArn("arn:aws:iam::2222222222:role/fancy/role/path"));
+        assertTrue(awsIamRoleArnParser.isRoleArn("arn:aws:iam::1111111111:role/name"));
+        assertFalse(awsIamRoleArnParser.isRoleArn("arn:aws:iam::3333333333:assumed-role/happy/path"));
+        assertFalse(awsIamRoleArnParser.isRoleArn("arn:aws:sts::1111111111:federated-user/my_user"));
+        assertFalse(awsIamRoleArnParser.isRoleArn("arn:aws:iam::1111111111:group/path/to/group"));
     }
 }


### PR DESCRIPTION
This fixes IAM authentication for IAM assumed roles via the v2 API, and enables all other principals to authenticate