### PR TITLE
Make sure vault policies exist after restore

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,6 +14,6 @@
 # limitations under the License.
 #
 
-version=0.20.0
+version=0.20.2
 groupId=com.nike.cerberus
 artifactId=cms

--- a/src/main/java/com/nike/cerberus/service/SafeDepositBoxService.java
+++ b/src/main/java/com/nike/cerberus/service/SafeDepositBoxService.java
@@ -749,6 +749,9 @@ public class SafeDepositBoxService {
             updateOwner(safeDepositBox.getId(), safeDepositBox.getOwner(), adminUser, now);
             modifyUserGroupPermissions(existingBox, safeDepositBox.getUserGroupPermissions(), adminUser, now);
             modifyIamPrincipalPermissions(existingBox, safeDepositBox.getIamPrincipalPermissions(), adminUser, now);
+
+            // add/update the vault policies, in case they were tampered with or deleted
+            vaultPolicyService.createStandardPolicies(safeDepositBox.getName(), safeDepositBox.getPath());
         } else {
             safeDepositBoxDao.createSafeDepositBox(boxToStore);
             addOwnerPermission(safeDepositBox.getUserGroupPermissions(), safeDepositBox.getOwner());


### PR DESCRIPTION
Update the standard vault policies on restore, even if the SDB already exists, in case the policies were tampered with or deleted.