### PR TITLE
Fix Authentication in OktaMFAAuthConnector

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,6 +14,6 @@
 # limitations under the License.
 #
 
-version=0.20.3
+version=0.20.4
 groupId=com.nike.cerberus
 artifactId=cms

--- a/src/main/java/com/nike/cerberus/auth/connector/okta/OktaClientResponseUtils.java
+++ b/src/main/java/com/nike/cerberus/auth/connector/okta/OktaClientResponseUtils.java
@@ -35,7 +35,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Created by sford4 on 1/30/17.
+ * Helper class to parse Okta API responses
  */
 public class OktaClientResponseUtils {
 

--- a/src/test/java/com/nike/cerberus/auth/connector/okta/OktaApiClientHelperTest.java
+++ b/src/test/java/com/nike/cerberus/auth/connector/okta/OktaApiClientHelperTest.java
@@ -23,7 +23,9 @@ import com.okta.sdk.clients.AuthApiClient;
 import com.okta.sdk.clients.FactorsApiClient;
 import com.okta.sdk.clients.UserApiClient;
 import com.okta.sdk.models.auth.AuthResult;
+import com.okta.sdk.models.factors.Verification;
 import com.okta.sdk.models.usergroups.UserGroup;
+import com.okta.sdk.models.users.User;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -34,6 +36,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -116,6 +119,33 @@ public class OktaApiClientHelperTest {
 
         // do the call
         this.oktaApiClientHelper.verifyFactor("factor id", "state token", "pass code");
+    }
+
+    @Test
+    public void verifyFactorMfaNotRequiredForUserInOktaHappy() throws Exception {
+
+        String factorId = "factor id";
+        String passCode = "pass code";
+        String userId = "user id";
+
+        User user = mock(User.class);
+        when(userApiClient.getUser(userId)).thenReturn(user);
+
+        User result = this.oktaApiClientHelper.verifyFactorMfaNotRequiredForUserInOkta(factorId, userId, passCode);
+
+        assertEquals(user, result);
+    }
+
+    @Test(expected = ApiException.class)
+    public void verifyFactorMfaNotRequiredForUserInOktaFailsIO() throws Exception {
+
+        String factorId = "factor id";
+        String passCode = "pass code";
+        String userId = "user id";
+
+        when(factorsApiClient.verifyFactor(anyString(), anyString(), anyObject())).thenThrow(IOException.class);
+
+        this.oktaApiClientHelper.verifyFactorMfaNotRequiredForUserInOkta(factorId, userId, passCode);
     }
 
     @Test

--- a/src/test/java/com/nike/cerberus/auth/connector/okta/OktaMFAAuthConnectorTest.java
+++ b/src/test/java/com/nike/cerberus/auth/connector/okta/OktaMFAAuthConnectorTest.java
@@ -25,6 +25,8 @@ import com.okta.sdk.models.auth.AuthResult;
 import com.okta.sdk.models.factors.Factor;
 import com.okta.sdk.models.usergroups.UserGroup;
 import com.okta.sdk.models.usergroups.UserGroupProfile;
+import com.okta.sdk.models.users.User;
+import com.okta.sdk.models.users.UserProfile;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
 import org.junit.Test;
@@ -218,6 +220,31 @@ public class OktaMFAAuthConnectorTest {
 
         // do the call
         AuthResponse result = this.oktaMFAAuthConnector.mfaCheck(stateToken, deviceId, otpToken);
+
+        // verify results
+        assertEquals(id, result.getData().getUserId());
+        assertEquals(email, result.getData().getUsername());
+    }
+
+    @Test
+    public void mfaCheckMfaNotRequiredForUserInOktaHappy() {
+
+        String email = "email";
+        String id = "id";
+
+        String stateToken = "userId:" + id;
+        String deviceId = "device id";
+        String otpToken = "otp token";
+
+        User user = new User();
+        UserProfile profile = new UserProfile();
+        profile.setLogin(email);
+        user.setId(id);
+        user.setProfile(profile);
+        when(oktaApiClientHelper.verifyFactorMfaNotRequiredForUserInOkta(deviceId, id, otpToken)).thenReturn(user);
+
+        // do the call
+        AuthResponse result = this.oktaMFAAuthConnector.mfaCheckMfaNotRequiredForUserInOkta(stateToken, deviceId, otpToken);
 
         // verify results
         assertEquals(id, result.getData().getUserId());


### PR DESCRIPTION
Fixes the issue where authentication fails with the OktaMFAAuthConnector if MFA is not required in Okta for the user.

**Note: This fix depends on dashboard change: Nike-Inc/cerberus-management-dashboard#23