### PR TITLE
Clean up inactive or orphaned records

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,6 +14,6 @@
 # limitations under the License.
 #
 
-version=0.20.3
+version=0.21.0
 groupId=com.nike.cerberus
 artifactId=cms

--- a/src/main/java/com/nike/cerberus/dao/AwsIamRoleDao.java
+++ b/src/main/java/com/nike/cerberus/dao/AwsIamRoleDao.java
@@ -22,6 +22,7 @@ import com.nike.cerberus.record.AwsIamRolePermissionRecord;
 import com.nike.cerberus.record.AwsIamRoleRecord;
 
 import javax.inject.Inject;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -79,5 +80,21 @@ public class AwsIamRoleDao {
 
     public int updateIamRoleKmsKey(final AwsIamRoleKmsKeyRecord record) {
         return awsIamRoleMapper.updateIamRoleKmsKey(record);
+    }
+
+    public List<AwsIamRoleKmsKeyRecord> getInactiveOrOrphanedKmsKeys(final OffsetDateTime keyInactiveDateTime) {
+        return awsIamRoleMapper.getInactiveOrOrphanedKmsKeys(keyInactiveDateTime);
+    }
+
+    public List<AwsIamRoleRecord> getOrphanedIamRoles() {
+        return awsIamRoleMapper.getOrphanedIamRoles();
+    }
+
+    public int deleteIamRoleById(final String id) {
+        return awsIamRoleMapper.deleteIamRoleById(id);
+    }
+
+    public int deleteKmsKeyById(final String id) {
+        return awsIamRoleMapper.deleteKmsKeyById(id);
     }
 }

--- a/src/main/java/com/nike/cerberus/domain/CleanUpRequest.java
+++ b/src/main/java/com/nike/cerberus/domain/CleanUpRequest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2016 Nike, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nike.cerberus.domain;
+
+/**
+ * Clean up KMS key request.
+ */
+public class CleanUpRequest {
+
+    private Integer kmsExpirationPeriodInDays;
+
+    public Integer getKmsExpirationPeriodInDays() {
+        return kmsExpirationPeriodInDays;
+    }
+
+    public CleanUpRequest setKmsExpirationPeriodInDays(Integer kmsExpirationPeriodInDays) {
+        this.kmsExpirationPeriodInDays = kmsExpirationPeriodInDays;
+        return this;
+    }
+}

--- a/src/main/java/com/nike/cerberus/domain/IamRolePermission.java
+++ b/src/main/java/com/nike/cerberus/domain/IamRolePermission.java
@@ -36,11 +36,9 @@ public class IamRolePermission {
     @Pattern(regexp = IAM_ROLE_ACCT_ID_REGEX, message = "IAM_ROLE_ACCT_ID_INVALID", groups = {Default.class, Updatable.class})
     private String accountId;
 
-    // TODO: remove
     @Pattern(regexp = IAM_ROLE_NAME_REGEX, message = "IAM_ROLE_NAME_INVALID", groups = {Default.class, Updatable.class})
     private String iamRoleName;
 
-    // TODO: remove
     @NotBlank(message = "IAM_ROLE_ROLE_ID_INVALID", groups = {Default.class, Updatable.class})
     private String roleId;
 

--- a/src/main/java/com/nike/cerberus/endpoints/admin/CleanUpInactiveOrOrphanedRecords.java
+++ b/src/main/java/com/nike/cerberus/endpoints/admin/CleanUpInactiveOrOrphanedRecords.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2017 Nike, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nike.cerberus.endpoints.admin;
+
+import com.google.inject.Inject;
+import com.nike.cerberus.domain.CleanUpRequest;
+import com.nike.cerberus.endpoints.AdminStandardEndpoint;
+import com.nike.cerberus.security.VaultAuthPrincipal;
+import com.nike.cerberus.service.CleanUpService;
+import com.nike.riposte.server.http.RequestInfo;
+import com.nike.riposte.server.http.ResponseInfo;
+import com.nike.riposte.server.http.impl.FullResponseInfo;
+import com.nike.riposte.util.AsyncNettyHelper;
+import com.nike.riposte.util.Matcher;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.core.SecurityContext;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+/**
+ * Cleans up inactive or orphaned KMS keys and IAM roles.
+ *
+ * This is required because orphaned CMKs, KMS key DB records, and IAM role DB records are created when an SDB is deleted.
+ * Thus this endpoint exists to clean up those already existing orphaned records in the DB, as well as orphaned records
+ * made from future SDB deletions.
+ *
+ * The reason that this clean up is not done at the time of SDB deletion is to lessen code complexity and give control
+ * to the administrators over when KMS keys are deleted.
+ */
+public class CleanUpInactiveOrOrphanedRecords extends AdminStandardEndpoint<CleanUpRequest, Void> {
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    private static final int DEFAULT_KMS_KEY_INACTIVE_AFTER_N_DAYS = 30;
+
+    private final CleanUpService cleanUpService;
+
+    @Inject
+    public CleanUpInactiveOrOrphanedRecords(CleanUpService cleanUpService) {
+        this.cleanUpService = cleanUpService;
+    }
+
+    @Override
+    public CompletableFuture<ResponseInfo<Void>> doExecute(final RequestInfo<CleanUpRequest> request,
+                                                           final Executor longRunningTaskExecutor,
+                                                           final ChannelHandlerContext ctx,
+                                                           final SecurityContext securityContext) {
+        return CompletableFuture.supplyAsync(
+                AsyncNettyHelper.supplierWithTracingAndMdc(() -> cleanUp(request, securityContext), ctx),
+                longRunningTaskExecutor
+        );
+    }
+
+    private FullResponseInfo<Void> cleanUp(final RequestInfo<CleanUpRequest> request,
+                                           final SecurityContext securityContext) {
+
+        final VaultAuthPrincipal vaultAuthPrincipal = (VaultAuthPrincipal) securityContext.getUserPrincipal();
+        final String principal = vaultAuthPrincipal.getName();
+
+        log.info("Clean Up Event: the principal {} is attempting to clean up kms keys", principal);
+
+        Integer expirationPeriodInDays = request.getContent().getKmsExpirationPeriodInDays();
+        int kmsKeysInactiveAfterNDays = (expirationPeriodInDays == null) ? DEFAULT_KMS_KEY_INACTIVE_AFTER_N_DAYS : expirationPeriodInDays;
+
+        cleanUpService.cleanUpInactiveAndOrphanedKmsKeys(kmsKeysInactiveAfterNDays);
+        cleanUpService.cleanUpOrphanedIamRoles();
+
+        return ResponseInfo.<Void>newBuilder()
+                .withHttpStatusCode(HttpResponseStatus.NO_CONTENT.code())
+                .build();
+    }
+
+    @Override
+    public Matcher requestMatcher() {
+        return Matcher.match("/v1/cleanup", HttpMethod.PUT);
+    }
+
+}

--- a/src/main/java/com/nike/cerberus/mapper/AwsIamRoleMapper.java
+++ b/src/main/java/com/nike/cerberus/mapper/AwsIamRoleMapper.java
@@ -21,6 +21,7 @@ import com.nike.cerberus.record.AwsIamRolePermissionRecord;
 import com.nike.cerberus.record.AwsIamRoleRecord;
 import org.apache.ibatis.annotations.Param;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 
 /**
@@ -51,4 +52,12 @@ public interface AwsIamRoleMapper {
     int deleteIamRolePermissions(@Param("safeDepositBoxId") String safeDepositBoxId);
 
     int updateIamRoleKmsKey(@Param("record") AwsIamRoleKmsKeyRecord record);
+
+    List<AwsIamRoleKmsKeyRecord> getInactiveOrOrphanedKmsKeys(@Param("keyInactiveDateTime") OffsetDateTime keyInactiveDateTime);
+
+    List<AwsIamRoleRecord> getOrphanedIamRoles();
+
+    int deleteIamRoleById(@Param("id") final String id);
+
+    int deleteKmsKeyById(@Param("id") final String id);
 }

--- a/src/main/java/com/nike/cerberus/server/config/guice/CmsGuiceModule.java
+++ b/src/main/java/com/nike/cerberus/server/config/guice/CmsGuiceModule.java
@@ -22,6 +22,7 @@ import com.google.inject.name.Names;
 import com.nike.backstopper.apierror.projectspecificinfo.ProjectApiErrors;
 import com.nike.cerberus.config.CmsEnvPropertiesLoader;
 import com.nike.cerberus.endpoints.HealthCheckEndpoint;
+import com.nike.cerberus.endpoints.admin.CleanUpInactiveOrOrphanedRecords;
 import com.nike.cerberus.endpoints.admin.GetSDBMetadata;
 import com.nike.cerberus.endpoints.admin.PutSDBMetadata;
 import com.nike.cerberus.endpoints.authentication.AuthenticateIamRole;
@@ -184,7 +185,8 @@ public class CmsGuiceModule extends AbstractModule {
             CreateSafeDepositBoxV1 createSafeDepositBoxV1,
             CreateSafeDepositBoxV2 createSafeDepositBoxV2,
             GetSDBMetadata getSDBMetadata,
-            PutSDBMetadata putSDBMetadata
+            PutSDBMetadata putSDBMetadata,
+            CleanUpInactiveOrOrphanedRecords cleanUpInactiveOrOrphanedRecords
     ) {
         return new LinkedHashSet<>(Arrays.<Endpoint<?>>asList(
                 healthCheckEndpoint,
@@ -194,7 +196,7 @@ public class CmsGuiceModule extends AbstractModule {
                 getAllRoles, getRole,
                 getSafeDepositBoxes, getSafeDepositBoxV1, getSafeDepositBoxV2,
                 deleteSafeDepositBox, updateSafeDepositBoxV1, updateSafeDepositBoxV2, createSafeDepositBoxV1, createSafeDepositBoxV2,
-                getSDBMetadata, putSDBMetadata
+                getSDBMetadata, putSDBMetadata, cleanUpInactiveOrOrphanedRecords
         ));
     }
 

--- a/src/main/java/com/nike/cerberus/service/CleanUpService.java
+++ b/src/main/java/com/nike/cerberus/service/CleanUpService.java
@@ -30,31 +30,17 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import static com.nike.cerberus.service.KmsService.SOONEST_A_KMS_KEY_CAN_BE_DELETED;
+
 /**
- * Utility to clean up inactive and orphaned KMS keys
+ * Service to clean up inactive and orphaned KMS keys
  */
 @Singleton
 public class CleanUpService {
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
-//    private static final String KMS_KEY_CLEAN_UP_INTERVAL_OVERRIDE = "cms.kms.cleanup.interval.hours.override";
-
-//    private static final Integer DEFAULT_KMS_KEY_CLEAN_UP_INTERVAL = 24; // in hours
-
-//    private static final String KMS_KEY_EXPIRATION_INTERVAL_OVERRIDE = "cms.kms.key.inactive.after.n.days.override";
-
-    private static final int DEFAULT_KMS_KEY_INACTIVE_AFTER_N_DAYS = 30;
-
-    private static final int DEFAULT_SLEEP_BETWEEN_KMS_CALLS = 15;  // in seconds
-
-//    @Inject(optional=true)
-//    @Named(KMS_KEY_CLEAN_UP_INTERVAL_OVERRIDE)
-//    private Integer kmsKeyCleanUpInterval = DEFAULT_KMS_KEY_CLEAN_UP_INTERVAL;
-
-//    @Inject(optional=true)
-//    @Named(KMS_KEY_EXPIRATION_INTERVAL_OVERRIDE)
-//    private Integer kmsKeyInactiveAfterNDays = DEFAULT_KMS_KEY_INACTIVE_AFTER_N_DAYS;
+    private static final int DEFAULT_SLEEP_BETWEEN_KMS_CALLS = 10;  // in seconds
 
     private final KmsService kmsService;
 
@@ -71,56 +57,74 @@ public class CleanUpService {
         this.dateTimeSupplier = dateTimeSupplier;
     }
 
-//    public void scheduleKmsKeyCleanUp() {
-//        // schedule one task to:
-//            // clean up inactive and orphaned kms keys
-//
-//        throw new UnsupportedOperationException("Not yet implemented.");
-//    }
-//
-//    public void scheduleIamRoleCleanUp() {
-//
-//        // schedule one task to:
-//            // clean up orphaned iam roles
-//
-//        throw new UnsupportedOperationException("Not yet implemented.");
-//    }
+    /**
+     * Delete all AWS KMS keys and DB records for KMS keys that have not been used recently
+     * or are no longer associated with an SDB.
+     */
+    public void cleanUpInactiveAndOrphanedKmsKeys(final int kmsKeysInactiveAfterNDays) {
+
+        cleanUpInactiveAndOrphanedKmsKeys(kmsKeysInactiveAfterNDays, DEFAULT_SLEEP_BETWEEN_KMS_CALLS);
+    }
 
     /**
-     * Delete all KMS keys and DB records for keys that have not been used recently and are no longer associated with an SDB.
+     * Delete all AWS KMS keys and DB records for KMS keys that have not been used recently
+     * or are no longer associated with an SDB.
+     * @param kmsKeysInactiveAfterNDays - Consider KMS keys to be inactive after 'n' number of days
+     * @param sleepInSeconds - Sleep for 'n' seconds between AWS calls, to keep from exceeding the API limit
      */
-    private void cleanUpInactiveAndOrphanedKmsKeys() {
+    protected void cleanUpInactiveAndOrphanedKmsKeys(final int kmsKeysInactiveAfterNDays, final int sleepInSeconds) {
 
         // get orphaned and inactive kms keys (not used in 'n' days)
-        final OffsetDateTime inactiveDateTime = dateTimeSupplier.get().minusDays(DEFAULT_KMS_KEY_INACTIVE_AFTER_N_DAYS);
+        final OffsetDateTime inactiveDateTime = dateTimeSupplier.get().minusDays(kmsKeysInactiveAfterNDays);
         final List<AwsIamRoleKmsKeyRecord> inactiveAndOrphanedKmsKeys = awsIamRoleDao.getInactiveOrOrphanedKmsKeys(inactiveDateTime);
 
-        // delete inactive and orphaned kms key records from DB
-        inactiveAndOrphanedKmsKeys.forEach(kmsKeyRecord -> {
-            try {
-                awsIamRoleDao.deleteKmsKeyById(kmsKeyRecord.getAwsKmsKeyId());
-                kmsService.deleteKmsKeyInAws(kmsKeyRecord.getAwsKmsKeyId(), kmsKeyRecord.getAwsRegion());
-                TimeUnit.SECONDS.sleep(DEFAULT_SLEEP_BETWEEN_KMS_CALLS);
-            } catch (InterruptedException ie) {
-                logger.error("Timeout between KMS key deletion was interrupted");
-            } catch(Exception e) {
-                logger.error("There was a problem deleting KMS key with id: {}, region: {}",
-                        kmsKeyRecord.getAwsIamRoleId(),
-                        kmsKeyRecord.getAwsRegion());
-            }
-        });
+        if (inactiveAndOrphanedKmsKeys.isEmpty()) {
+            logger.info("No keys to clean up.");
+        } else {
+
+            // delete inactive and orphaned kms key records from DB
+            logger.info("Cleaning up orphaned or inactive KMS keys...");
+            inactiveAndOrphanedKmsKeys.forEach(kmsKeyRecord -> {
+                try {
+                    logger.info("Deleting orphaned or inactive KMS key: id={}, region={}, lastValidated={}",
+                            kmsKeyRecord.getAwsKmsKeyId(), kmsKeyRecord.getAwsRegion(), kmsKeyRecord.getLastValidatedTs());
+
+                    kmsService.scheduleKmsKeyDeletion(kmsKeyRecord.getAwsKmsKeyId(), kmsKeyRecord.getAwsRegion(), SOONEST_A_KMS_KEY_CAN_BE_DELETED);
+                    awsIamRoleDao.deleteKmsKeyById(kmsKeyRecord.getId());
+
+                    TimeUnit.SECONDS.sleep(sleepInSeconds);
+                } catch (InterruptedException ie) {
+                    logger.error("Timeout between KMS key deletion was interrupted");
+                    Thread.currentThread().interrupt();
+                } catch (Exception e) {
+                    logger.error("There was a problem deleting KMS key with id: {}, region: {}",
+                            kmsKeyRecord.getAwsIamRoleId(),
+                            kmsKeyRecord.getAwsRegion());
+                }
+            });
+        }
     }
 
     /**
      * Delete all IAM role records that are no longer associated with an SDB.
      */
-    private void cleanUpOrphanedIamRoles() {
+    public void cleanUpOrphanedIamRoles() {
 
         // get orphaned iam role ids
-        List<AwsIamRoleRecord> orphanedIamRoleIds = awsIamRoleDao.getOrphanedIamRoles();
+        final List<AwsIamRoleRecord> orphanedIamRoleIds = awsIamRoleDao.getOrphanedIamRoles();
 
         // delete orphaned iam role records from DB
-        orphanedIamRoleIds.forEach(awsIamRoleRecord -> awsIamRoleDao.deleteIamRoleById(awsIamRoleRecord.getId()));
+        orphanedIamRoleIds.forEach(awsIamRoleRecord -> {
+            try {
+                logger.info("Deleting orphaned IAM role: ARN={}, lastUpdated={}",
+                        awsIamRoleRecord.getAwsIamRoleArn(),
+                        awsIamRoleRecord.getLastUpdatedTs());
+                awsIamRoleDao.deleteIamRoleById(awsIamRoleRecord.getId());
+            } catch(Exception e) {
+                logger.error("There was a problem deleting orphaned IAM role with ARN: {}",
+                    awsIamRoleRecord.getAwsIamRoleArn());
+            }
+        });
     }
 }
 

--- a/src/main/java/com/nike/cerberus/service/CleanUpService.java
+++ b/src/main/java/com/nike/cerberus/service/CleanUpService.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2017 Nike, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.nike.cerberus.service;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.nike.cerberus.dao.AwsIamRoleDao;
+import com.nike.cerberus.record.AwsIamRoleKmsKeyRecord;
+import com.nike.cerberus.record.AwsIamRoleRecord;
+import com.nike.cerberus.util.DateTimeSupplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Utility to clean up inactive and orphaned KMS keys
+ */
+@Singleton
+public class CleanUpService {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+//    private static final String KMS_KEY_CLEAN_UP_INTERVAL_OVERRIDE = "cms.kms.cleanup.interval.hours.override";
+
+//    private static final Integer DEFAULT_KMS_KEY_CLEAN_UP_INTERVAL = 24; // in hours
+
+//    private static final String KMS_KEY_EXPIRATION_INTERVAL_OVERRIDE = "cms.kms.key.inactive.after.n.days.override";
+
+    private static final int DEFAULT_KMS_KEY_INACTIVE_AFTER_N_DAYS = 30;
+
+    private static final int DEFAULT_SLEEP_BETWEEN_KMS_CALLS = 15;  // in seconds
+
+//    @Inject(optional=true)
+//    @Named(KMS_KEY_CLEAN_UP_INTERVAL_OVERRIDE)
+//    private Integer kmsKeyCleanUpInterval = DEFAULT_KMS_KEY_CLEAN_UP_INTERVAL;
+
+//    @Inject(optional=true)
+//    @Named(KMS_KEY_EXPIRATION_INTERVAL_OVERRIDE)
+//    private Integer kmsKeyInactiveAfterNDays = DEFAULT_KMS_KEY_INACTIVE_AFTER_N_DAYS;
+
+    private final KmsService kmsService;
+
+    private final AwsIamRoleDao awsIamRoleDao;
+
+    private final DateTimeSupplier dateTimeSupplier;
+
+    @Inject
+    public CleanUpService(KmsService kmsService,
+                          AwsIamRoleDao awsIamRoleDao,
+                          DateTimeSupplier dateTimeSupplier) {
+        this.kmsService = kmsService;
+        this.awsIamRoleDao = awsIamRoleDao;
+        this.dateTimeSupplier = dateTimeSupplier;
+    }
+
+//    public void scheduleKmsKeyCleanUp() {
+//        // schedule one task to:
+//            // clean up inactive and orphaned kms keys
+//
+//        throw new UnsupportedOperationException("Not yet implemented.");
+//    }
+//
+//    public void scheduleIamRoleCleanUp() {
+//
+//        // schedule one task to:
+//            // clean up orphaned iam roles
+//
+//        throw new UnsupportedOperationException("Not yet implemented.");
+//    }
+
+    /**
+     * Delete all KMS keys and DB records for keys that have not been used recently and are no longer associated with an SDB.
+     */
+    private void cleanUpInactiveAndOrphanedKmsKeys() {
+
+        // get orphaned and inactive kms keys (not used in 'n' days)
+        final OffsetDateTime inactiveDateTime = dateTimeSupplier.get().minusDays(DEFAULT_KMS_KEY_INACTIVE_AFTER_N_DAYS);
+        final List<AwsIamRoleKmsKeyRecord> inactiveAndOrphanedKmsKeys = awsIamRoleDao.getInactiveOrOrphanedKmsKeys(inactiveDateTime);
+
+        // delete inactive and orphaned kms key records from DB
+        inactiveAndOrphanedKmsKeys.forEach(kmsKeyRecord -> {
+            try {
+                awsIamRoleDao.deleteKmsKeyById(kmsKeyRecord.getAwsKmsKeyId());
+                kmsService.deleteKmsKeyInAws(kmsKeyRecord.getAwsKmsKeyId(), kmsKeyRecord.getAwsRegion());
+                TimeUnit.SECONDS.sleep(DEFAULT_SLEEP_BETWEEN_KMS_CALLS);
+            } catch (InterruptedException ie) {
+                logger.error("Timeout between KMS key deletion was interrupted");
+            } catch(Exception e) {
+                logger.error("There was a problem deleting KMS key with id: {}, region: {}",
+                        kmsKeyRecord.getAwsIamRoleId(),
+                        kmsKeyRecord.getAwsRegion());
+            }
+        });
+    }
+
+    /**
+     * Delete all IAM role records that are no longer associated with an SDB.
+     */
+    private void cleanUpOrphanedIamRoles() {
+
+        // get orphaned iam role ids
+        List<AwsIamRoleRecord> orphanedIamRoleIds = awsIamRoleDao.getOrphanedIamRoles();
+
+        // delete orphaned iam role records from DB
+        orphanedIamRoleIds.forEach(awsIamRoleRecord -> awsIamRoleDao.deleteIamRoleById(awsIamRoleRecord.getId()));
+    }
+}
+

--- a/src/main/resources/com/nike/cerberus/mapper/AwsIamRoleMapper.xml
+++ b/src/main/resources/com/nike/cerberus/mapper/AwsIamRoleMapper.xml
@@ -48,7 +48,7 @@
       AWS_IAM_ROLE_ARN = #{awsIamRoleArn}
   </select>
 
-  <select id="getOrphanedIamRoles" resultType="AwsIamRole">
+  <select id="getOrphanedIamRoles" resultType="AwsIamRoleRecord">
     SELECT
       *
     FROM
@@ -59,7 +59,7 @@
           FROM
             AWS_IAM_ROLE_PERMISSIONS
           WHERE
-            AWS_IAM_ROLE.ID = AWS_IAM_ROLE_PERMISSIONS.AWS_IAM_ROLE_ID);
+            AWS_IAM_ROLE.ID = AWS_IAM_ROLE_PERMISSIONS.AWS_IAM_ROLE_ID)
   </select>
 
   <select id="getKmsKey" resultType="AwsIamRoleKmsKeyRecord">
@@ -87,14 +87,16 @@
     FROM
       AWS_IAM_ROLE_KMS_KEY
     WHERE
-      LAST_VALIDATED_TS < #{keyInactiveDateTime}
-        OR
-      NOT EXISTS
-        (SELECT *
-          FROM
-            AWS_IAM_ROLE_PERMISSIONS
-          WHERE
-            AWS_IAM_ROLE_KMS_KEY.AWS_IAM_ROLE_ID = AWS_IAM_ROLE_PERMISSIONS.AWS_IAM_ROLE_ID);
+        LAST_VALIDATED_TS &lt; #{keyInactiveDateTime}
+      OR
+        NOT EXISTS
+          (
+             SELECT *
+               FROM
+                 AWS_IAM_ROLE_PERMISSIONS
+               WHERE
+                 AWS_IAM_ROLE_KMS_KEY.AWS_IAM_ROLE_ID = AWS_IAM_ROLE_PERMISSIONS.AWS_IAM_ROLE_ID
+           )
   </select>
 
   <insert id="createIamRoleKmsKey" parameterType="AwsIamRoleKmsKeyRecord">

--- a/src/main/resources/com/nike/cerberus/mapper/AwsIamRoleMapper.xml
+++ b/src/main/resources/com/nike/cerberus/mapper/AwsIamRoleMapper.xml
@@ -48,6 +48,20 @@
       AWS_IAM_ROLE_ARN = #{awsIamRoleArn}
   </select>
 
+  <select id="getOrphanedIamRoles" resultType="AwsIamRole">
+    SELECT
+      *
+    FROM
+      AWS_IAM_ROLE
+    WHERE
+      NOT EXISTS
+        (SELECT *
+          FROM
+            AWS_IAM_ROLE_PERMISSIONS
+          WHERE
+            AWS_IAM_ROLE.ID = AWS_IAM_ROLE_PERMISSIONS.AWS_IAM_ROLE_ID);
+  </select>
+
   <select id="getKmsKey" resultType="AwsIamRoleKmsKeyRecord">
     SELECT
       ID,
@@ -65,6 +79,22 @@
         AWS_IAM_ROLE_ID = #{awsIamRoleId}
       AND
         AWS_REGION = #{awsRegion}
+  </select>
+
+  <select id="getInactiveOrOrphanedKmsKeys" resultType="AwsIamRoleKmsKeyRecord">
+    SELECT
+      *
+    FROM
+      AWS_IAM_ROLE_KMS_KEY
+    WHERE
+      LAST_VALIDATED_TS < #{keyInactiveDateTime}
+        OR
+      NOT EXISTS
+        (SELECT *
+          FROM
+            AWS_IAM_ROLE_PERMISSIONS
+          WHERE
+            AWS_IAM_ROLE_KMS_KEY.AWS_IAM_ROLE_ID = AWS_IAM_ROLE_PERMISSIONS.AWS_IAM_ROLE_ID);
   </select>
 
   <insert id="createIamRoleKmsKey" parameterType="AwsIamRoleKmsKeyRecord">
@@ -190,6 +220,20 @@
       AWS_IAM_ROLE_PERMISSIONS
     WHERE
       SDBOX_ID = #{safeDepositBoxId}
+  </delete>
+
+  <delete id="deleteIamRoleById">
+    DELETE FROM
+      AWS_IAM_ROLE
+    WHERE
+      ID = #{id}
+  </delete>
+
+  <delete id="deleteKmsKeyById">
+    DELETE FROM
+      AWS_IAM_ROLE_KMS_KEY
+    WHERE
+      ID = #{id}
   </delete>
 
 </mapper>

--- a/src/test/java/com/nike/cerberus/dao/AwsIamRoleDaoTest.java
+++ b/src/test/java/com/nike/cerberus/dao/AwsIamRoleDaoTest.java
@@ -257,4 +257,24 @@ public class AwsIamRoleDaoTest {
 
         assertThat(actualCount).isEqualTo(recordCount);
     }
+
+    @Test
+    public void deleteIamRoleById_returns_record_count() {
+        final int recordCount = 1;
+        when(awsIamRoleMapper.deleteIamRoleById(iamRoleId)).thenReturn(recordCount);
+
+        final int actualCount = subject.deleteIamRoleById(iamRoleId);
+
+        assertThat(actualCount).isEqualTo(recordCount);
+    }
+
+    @Test
+    public void deleteKmsKeyById_returns_record_count() {
+        final int recordCount = 1;
+        when(awsIamRoleMapper.deleteKmsKeyById(iamRoleKmsKeyId)).thenReturn(recordCount);
+
+        final int actualCount = subject.deleteIamRolePermissions(iamRoleKmsKeyId);
+
+        assertThat(actualCount).isEqualTo(recordCount);
+    }
 }

--- a/src/test/java/com/nike/cerberus/dao/AwsIamRoleDaoTest.java
+++ b/src/test/java/com/nike/cerberus/dao/AwsIamRoleDaoTest.java
@@ -273,7 +273,7 @@ public class AwsIamRoleDaoTest {
         final int recordCount = 1;
         when(awsIamRoleMapper.deleteKmsKeyById(iamRoleKmsKeyId)).thenReturn(recordCount);
 
-        final int actualCount = subject.deleteIamRolePermissions(iamRoleKmsKeyId);
+        final int actualCount = subject.deleteKmsKeyById(iamRoleKmsKeyId);
 
         assertThat(actualCount).isEqualTo(recordCount);
     }

--- a/src/test/java/com/nike/cerberus/domain/DomainPojoTest.java
+++ b/src/test/java/com/nike/cerberus/domain/DomainPojoTest.java
@@ -20,7 +20,7 @@ public class DomainPojoTest {
 
         List<PojoClass> pojoClasses = PojoClassFactory.getPojoClasses("com.nike.cerberus.domain");
 
-        Assert.assertEquals(18, pojoClasses.size());
+        Assert.assertEquals(19, pojoClasses.size());
 
         Validator validator = ValidatorBuilder.create()
                 .with(new GetterMustExistRule())

--- a/src/test/java/com/nike/cerberus/service/CleanUpServiceTest.java
+++ b/src/test/java/com/nike/cerberus/service/CleanUpServiceTest.java
@@ -1,0 +1,123 @@
+package com.nike.cerberus.service;
+
+import com.nike.cerberus.dao.AwsIamRoleDao;
+import com.nike.cerberus.record.AwsIamRoleKmsKeyRecord;
+import com.nike.cerberus.record.AwsIamRoleRecord;
+import com.nike.cerberus.util.DateTimeSupplier;
+import org.assertj.core.util.Lists;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import java.time.OffsetDateTime;
+
+import static com.nike.cerberus.service.KmsService.SOONEST_A_KMS_KEY_CAN_BE_DELETED;
+import static java.time.ZoneOffset.UTC;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+/**
+ * Tests the CleanUpService class
+ */
+public class CleanUpServiceTest {
+
+    // class under test
+    private CleanUpService cleanUpService;
+
+    // dependencies
+    @Mock
+    private KmsService kmsService;
+
+    @Mock
+    private AwsIamRoleDao awsIamRoleDao;
+
+    @Mock
+    private DateTimeSupplier dateTimeSupplier;
+
+    private OffsetDateTime now = OffsetDateTime.now(UTC);
+
+    @Before
+    public void setup() {
+
+        initMocks(this);
+
+        cleanUpService = new CleanUpService(kmsService, awsIamRoleDao, dateTimeSupplier);
+    }
+
+    @Test
+    public void test_that_cleanUpInactiveAndOrphanedKmsKeys_succeeds() {
+
+        int inactivePeriod = 30;
+        String keyRecordId = "key record id";
+        String awsKeyId = "aws key id";
+        String keyRegion = "key region";
+        AwsIamRoleKmsKeyRecord keyRecord = mock(AwsIamRoleKmsKeyRecord.class);
+        when(keyRecord.getId()).thenReturn(keyRecordId);
+        when(keyRecord.getAwsKmsKeyId()).thenReturn(awsKeyId);
+        when(keyRecord.getAwsRegion()).thenReturn(keyRegion);
+        when(dateTimeSupplier.get()).thenReturn(now);
+
+        OffsetDateTime inactiveCutoffDate = now.minusDays(inactivePeriod);
+        when(awsIamRoleDao.getInactiveOrOrphanedKmsKeys(inactiveCutoffDate)).thenReturn(Lists.newArrayList(keyRecord));
+
+        // perform the call
+        cleanUpService.cleanUpInactiveAndOrphanedKmsKeys(inactivePeriod, 0);
+
+        verify(awsIamRoleDao).getInactiveOrOrphanedKmsKeys(inactiveCutoffDate);
+        verify(awsIamRoleDao).deleteKmsKeyById(keyRecordId);
+        verify(kmsService).scheduleKmsKeyDeletion(awsKeyId, keyRegion, SOONEST_A_KMS_KEY_CAN_BE_DELETED);
+    }
+
+    @Test
+    public void test_that_cleanUpInactiveAndOrphanedKmsKeys_does_not_throw_exception_on_failure() {
+
+        int inactivePeriod = 30;
+        String keyRecordId = "key record id";
+        String awsKeyId = "aws key id";
+        String keyRegion = "key region";
+        AwsIamRoleKmsKeyRecord keyRecord = mock(AwsIamRoleKmsKeyRecord.class);
+        when(keyRecord.getId()).thenReturn(keyRecordId);
+        when(keyRecord.getAwsKmsKeyId()).thenReturn(awsKeyId);
+        when(keyRecord.getAwsRegion()).thenReturn(keyRegion);
+        when(dateTimeSupplier.get()).thenReturn(now);
+
+        OffsetDateTime inactiveCutoffDate = now.minusDays(inactivePeriod);
+        when(awsIamRoleDao.getInactiveOrOrphanedKmsKeys(inactiveCutoffDate)).thenReturn(Lists.newArrayList(keyRecord));
+
+        when(awsIamRoleDao.deleteKmsKeyById(keyRecordId)).thenThrow(new NullPointerException());
+
+        cleanUpService.cleanUpInactiveAndOrphanedKmsKeys(inactivePeriod);
+    }
+
+    @Test
+    public void test_that_cleanUpOrphanedIamRoles_succeeds() {
+
+        String iamRoleRecordId = "iam role record id";
+        AwsIamRoleRecord roleRecord = mock(AwsIamRoleRecord.class);
+        when(roleRecord.getId()).thenReturn(iamRoleRecordId);
+
+        when(awsIamRoleDao.getOrphanedIamRoles()).thenReturn(Lists.newArrayList(roleRecord));
+
+        // perform the call
+        cleanUpService.cleanUpOrphanedIamRoles();
+
+        verify(awsIamRoleDao).getOrphanedIamRoles();
+        verify(awsIamRoleDao).deleteIamRoleById(iamRoleRecordId);
+    }
+
+    @Test
+    public void test_that_cleanUpOrphanedIamRoles_does_not_throw_exception_on_failure() {
+
+        String iamRoleRecordId = "iam role record id";
+        AwsIamRoleRecord roleRecord = mock(AwsIamRoleRecord.class);
+        when(roleRecord.getId()).thenReturn(iamRoleRecordId);
+
+        when(awsIamRoleDao.getOrphanedIamRoles()).thenReturn(Lists.newArrayList(roleRecord));
+
+        when(awsIamRoleDao.deleteIamRoleById(iamRoleRecordId)).thenThrow(new NullPointerException());
+
+        cleanUpService.cleanUpOrphanedIamRoles();
+    }
+}


### PR DESCRIPTION
Add an admin endpoint to clean up orphaned IAM roles in the DB and inactive or orphaned KMS keys in the SDB and in AWS.
 
This is required because orphaned CMKs, KMS key DB records, and IAM role DB records are created when an SDB is deleted. Thus, this endpoint will be used to clean up those already existing orphaned records in the DB, as well as orphaned records made from future SDB deletions.

The reason that this clean up is not done at the time of SDB deletion is to lessen code complexity and give control to the administrators over when KMS keys are deleted.