### PR TITLE
Give CMS permissions to schedule and cancel KMS key deletion

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,6 +14,6 @@
 # limitations under the License.
 #
 
-version=0.22.0
+version=0.24.0
 groupId=com.nike.cerberus
 artifactId=cms

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -23,7 +23,7 @@ def riposteVersion = '0.9.4'
 def logbackVersion = '1.1.7'
 // Request version 4 for full java 8 support
 def guiceVersion = '4.0'
-def awsSdkVersion = '1.11.108'
+def awsSdkVersion = '1.11.160'
 def groovyVersion = '2.3.9'
 
 dependencies {

--- a/src/main/java/com/nike/cerberus/service/AuthenticationService.java
+++ b/src/main/java/com/nike/cerberus/service/AuthenticationService.java
@@ -498,6 +498,7 @@ public class AuthenticationService {
             kmsKeyRecord = kmsKey.get();
             kmsKeyId = kmsKeyRecord.getAwsKmsKeyId();
             kmsService.validatePolicy(kmsKeyRecord, iamPrincipalArn);
+            kmsService.validateKmsKeyIsUsable(kmsKeyRecord, iamPrincipalArn);
         }
 
         return kmsKeyId;

--- a/src/main/java/com/nike/cerberus/service/CleanUpService.java
+++ b/src/main/java/com/nike/cerberus/service/CleanUpService.java
@@ -24,6 +24,7 @@ import com.nike.cerberus.domain.CleanUpRequest;
 import com.nike.cerberus.record.AwsIamRoleKmsKeyRecord;
 import com.nike.cerberus.record.AwsIamRoleRecord;
 import com.nike.cerberus.util.DateTimeSupplier;
+import org.mybatis.guice.transactional.Transactional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -102,7 +103,7 @@ public class CleanUpService {
                             kmsKeyArn, kmsKeyRegion, kmsKeyRecord.getLastValidatedTs());
                     kmsService.validatePolicyAllowsCMSToDeleteCMK(kmsKeyArn, kmsKeyRegion);
                     kmsService.scheduleKmsKeyDeletion(kmsKeyArn, kmsKeyRegion, SOONEST_A_KMS_KEY_CAN_BE_DELETED);
-                    awsIamRoleDao.deleteKmsKeyById(kmsKeyRecord.getId());
+                    kmsService.deleteKmsKeyById(kmsKeyRecord.getId());
                     TimeUnit.SECONDS.sleep(sleepInSeconds);
                 } catch (InterruptedException ie) {
                     logger.error("Timeout between KMS key deletion was interrupted", ie);
@@ -120,6 +121,7 @@ public class CleanUpService {
     /**
      * Delete all IAM role records that are no longer associated with an SDB.
      */
+    @Transactional
     protected void cleanUpOrphanedIamRoles() {
 
         // get orphaned iam role ids

--- a/src/main/java/com/nike/cerberus/service/KmsPolicyService.java
+++ b/src/main/java/com/nike/cerberus/service/KmsPolicyService.java
@@ -18,17 +18,22 @@ package com.nike.cerberus.service;
 
 import com.amazonaws.auth.policy.Action;
 import com.amazonaws.auth.policy.Policy;
+import com.amazonaws.auth.policy.PolicyReaderOptions;
 import com.amazonaws.auth.policy.Principal;
 import com.amazonaws.auth.policy.Resource;
 import com.amazonaws.auth.policy.Statement;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.amazonaws.auth.policy.actions.KMSActions;
+import com.amazonaws.auth.policy.internal.JsonPolicyReader;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Helpful service for putting together the KMS policy documents to be associated with provisioned KMS keys.
@@ -45,7 +50,10 @@ public class KmsPolicyService {
     private static final String CMS_ROLE_ARN_PROPERTY = "cms.role.arn";
 
     private static final String AWS_PROVIDER = "AWS";
+
     public static final String CERBERUS_CONSUMER_SID = "Target IAM Role Has Decrypt Action";
+
+    protected static final String CERBERUS_MANAGEMENT_SERVICE_SID = "CMS Role Key Access";
 
     private final String rootUserArn;
 
@@ -53,7 +61,7 @@ public class KmsPolicyService {
 
     private final String cmsRoleArn;
 
-    private final ObjectMapper objectMapper;
+    private final JsonPolicyReader policyReader;
 
     @Inject
     public KmsPolicyService(@Named(ROOT_USER_ARN_PROPERTY) String rootUserArn,
@@ -63,35 +71,42 @@ public class KmsPolicyService {
         this.adminRoleArn = adminRoleArn;
         this.cmsRoleArn = cmsRoleArn;
 
-        objectMapper = new ObjectMapper();
+        PolicyReaderOptions policyReaderOptions = new PolicyReaderOptions();
+        policyReaderOptions.setStripAwsPrincipalIdHyphensEnabled(false);
+        policyReader = new JsonPolicyReader(policyReaderOptions);
     }
 
-    /***
-     * Please note that currently in the AWS Core SDK 1.11.108 that Policy.fromJson strips hyphens from AWS ARN Principals
-     * and Hyphens are valid in IAM role names. We will need to manually use JsonNodes and not rely on fromJson
+    /**
+     * Validates that the given key policy grants appropriate permissions to CMS and allows the given IAM principal to
+     * access the KMS key.
      *
-     * When you manually instantiate a Principal you can specify true/false for striping hyphens,
-     * when deserializing with fromJson this seems to always get set to true.
-     *
-     * @param policyString - The KMS key policy as a String
+     * @param policyJson - The KMS key policy as a String
      * @param iamRoleArn - The IAM Role that is supposed to have decrypt permissions
      * @return true if the policy is valid, false if the policy contains an ID because the ARN had been deleted and recreated
      */
-    public boolean isPolicyValid(String policyString, String iamRoleArn) {
-        // The below json node stuff is lame, should be able to use Objects created from Policy.fromJson(string)
-        // todo file Github issue and or PR with AWS SDK project
+    public boolean isPolicyValid(String policyJson, String iamRoleArn) {
+
+        return iamPrincipalCanAccessKey(policyJson, iamRoleArn) && cmsHasKeyDeletePermissions(policyJson);
+    }
+
+    /**
+     * Check that the given IAM principal has permissions to access the KMS key.
+     *
+     * This is important because when an IAM principal is deleted and recreated with the same name, then the recreated
+     * principal cannot access the KMS key until the key policy is regenerated -- updating the policy permissions to
+     * allow the ARN of the recreated principal instead of the ID of the deleted principal.
+     *
+     * @param policyJson - The KMS key policy as a String
+     * @param iamPrincipalArn - The IAM Role that is supposed to have decrypt permissions
+     */
+    protected boolean iamPrincipalCanAccessKey(String policyJson, String iamPrincipalArn) {
         try {
-            JsonNode policy = null;
-            policy = objectMapper.readTree(policyString);
-            JsonNode statements = policy.get("Statement");
-            for (JsonNode statement : statements) {
-                if (CERBERUS_CONSUMER_SID.equals(statement.get("Sid").textValue())) {
-                    String statementAWSPrincipal = statement.get("Principal").get("AWS").textValue();
-                    if (iamRoleArn.equals(statementAWSPrincipal)) {
-                        return true;
-                    }
-                }
-            }
+            Policy policy = policyReader.createPolicyFromJsonString(policyJson);
+            return policy.getStatements()
+                    .stream()
+                    .anyMatch(statement ->
+                            StringUtils.equals(statement.getId(), CERBERUS_CONSUMER_SID) &&
+                                    statementAppliesToPrincipal(statement, iamPrincipalArn));
         } catch (Exception e) {
             // if we can't deserialize we will assume policy has been corrupted manually and regenerate it
             logger.error("Failed to validate policy, did someone manually edit the kms policy?", e);
@@ -100,36 +115,114 @@ public class KmsPolicyService {
         return false;
     }
 
+    /**
+     * Validate that the IAM principal for the CMS has permissions to schedule and cancel deletion of the KMS key.
+     * @param policyJson - The KMS key policy as a String
+     */
+    protected boolean cmsHasKeyDeletePermissions(String policyJson) {
+        try {
+            Policy policy = policyReader.createPolicyFromJsonString(policyJson);
+            return policy.getStatements()
+                    .stream()
+                    .anyMatch(statement ->
+                            StringUtils.equals(statement.getId(), CERBERUS_MANAGEMENT_SERVICE_SID) &&
+                                    statementAppliesToPrincipal(statement, cmsRoleArn) &&
+                                    statement.getEffect() == Statement.Effect.Allow &&
+                                    statementIncludesAction(statement, KMSActions.ScheduleKeyDeletion) &&
+                                    statementIncludesAction(statement, KMSActions.CancelKeyDeletion));
+        } catch (Exception e) {
+            logger.error("Failed to validate that CMS can delete KMS key, there may be something wrong with the policy", e);
+        }
+
+        return false;
+    }
+
+    /**
+     * Overwrite the policy statement for CMS with the standard statement. Add the standard statement for CMS
+     * to the policy if it did not already exist.
+     *
+     * @param policyJson - The KMS key policy in JSON format
+     * @return - The updated JSON KMS policy containing a regenerated statement for CMS
+     */
+    protected String overwriteCMSPolicy(String policyJson) {
+
+        Policy policy = policyReader.createPolicyFromJsonString(policyJson);
+        Collection<Statement> existingStatements = policy.getStatements();
+        List<Statement> policyStatementsExcludingCMS = existingStatements.stream()
+                .filter(statement -> ! StringUtils.equals(statement.getId(), CERBERUS_MANAGEMENT_SERVICE_SID))
+                .collect(Collectors.toList());
+        policyStatementsExcludingCMS.add(generateStandardCMSPolicyStatement());
+        policy.setStatements(policyStatementsExcludingCMS);
+        return policy.toJson();
+    }
+
+    /**
+     * Validates that the given KMS key policy statement applies to the given principal
+     */
+    protected boolean statementAppliesToPrincipal(Statement statement, String principalArn) {
+
+        return statement.getPrincipals()
+                .stream()
+                .anyMatch(principal ->
+                        StringUtils.equals(principal.getId(), principalArn));
+    }
+
+    /**
+     * Validates that the given KMS key policy statement includes the given action
+     */
+    protected boolean statementIncludesAction(Statement statement, Action action) {
+
+        return statement.getActions()
+                .stream()
+                .anyMatch(statementAction ->
+                        StringUtils.equals(statementAction.getActionName(), action.getActionName()));
+    }
+
+    /**
+     * Generates the standard KMS key policy statement for the Cerberus Management Service
+     */
+    protected Statement generateStandardCMSPolicyStatement() {
+        Statement cmsStatement = new Statement(Statement.Effect.Allow);
+        cmsStatement.withId(CERBERUS_MANAGEMENT_SERVICE_SID);
+        cmsStatement.withPrincipals(new Principal(AWS_PROVIDER, cmsRoleArn, false));
+        cmsStatement.withActions(
+                KMSActions.Encrypt,
+                KMSActions.Decrypt,
+                KMSActions.ReEncryptFrom,
+                KMSActions.ReEncryptTo,
+                KMSActions.GenerateDataKey,
+                KMSActions.GenerateDataKeyWithoutPlaintext,
+                KMSActions.GenerateRandom,
+                KMSActions.DescribeKey,
+                KMSActions.ScheduleKeyDeletion,
+                KMSActions.CancelKeyDeletion);
+        cmsStatement.withResources(new Resource("*"));
+
+        return cmsStatement;
+    }
+
     public String generateStandardKmsPolicy(String iamRoleArn) {
         Policy kmsPolicy = new Policy();
 
         Statement rootUserStatement = new Statement(Statement.Effect.Allow);
         rootUserStatement.withId("Root User Has All Actions");
         rootUserStatement.withPrincipals(new Principal(AWS_PROVIDER, rootUserArn, false));
-        rootUserStatement.withActions(KmsActions.AllKmsActions);
+        rootUserStatement.withActions(KMSActions.AllKMSActions);
         rootUserStatement.withResources(new Resource("*"));
 
         Statement keyAdministratorStatement = new Statement(Statement.Effect.Allow);
         keyAdministratorStatement.withId("Admin Role Has All Actions");
         keyAdministratorStatement.withPrincipals(new Principal(AWS_PROVIDER, adminRoleArn, false));
-        keyAdministratorStatement.withActions(KmsActions.AllKmsActions);
+        keyAdministratorStatement.withActions(KMSActions.AllKMSActions);
         keyAdministratorStatement.withResources(new Resource("*"));
 
-        Statement instanceUsageStatement = new Statement(Statement.Effect.Allow);
-        instanceUsageStatement.withId("CMS Role Key Access");
-        instanceUsageStatement.withPrincipals(new Principal(AWS_PROVIDER, cmsRoleArn, false));
-        instanceUsageStatement.withActions(KmsActions.EncryptAction,
-                KmsActions.DecryptAction,
-                KmsActions.AllReEncryptActions,
-                KmsActions.AllGenerateDataKeyActions,
-                KmsActions.DescribeKey);
-        instanceUsageStatement.withResources(new Resource("*"));
+        Statement instanceUsageStatement = generateStandardCMSPolicyStatement();
 
         Statement iamRoleUsageStatement = new Statement(Statement.Effect.Allow);
         iamRoleUsageStatement.withId(CERBERUS_CONSUMER_SID);
         iamRoleUsageStatement.withPrincipals(
                 new Principal(AWS_PROVIDER, iamRoleArn, false));
-        iamRoleUsageStatement.withActions(KmsActions.DecryptAction);
+        iamRoleUsageStatement.withActions(KMSActions.Decrypt);
         iamRoleUsageStatement.withResources(new Resource("*"));
 
         kmsPolicy.withStatements(rootUserStatement,
@@ -138,30 +231,5 @@ public class KmsPolicyService {
                 iamRoleUsageStatement);
 
         return kmsPolicy.toJson();
-    }
-
-    private enum KmsActions implements Action {
-        AllKmsActions("kms:*"),
-
-        EncryptAction("kms:Encrypt"),
-
-        DecryptAction("kms:Decrypt"),
-
-        AllReEncryptActions("kms:ReEncrypt*"),
-
-        AllGenerateDataKeyActions("kms:GenerateDataKey*"),
-
-        DescribeKey("kms:DescribeKey");
-
-        private final String action;
-
-        KmsActions(String action) {
-            this.action = action;
-        }
-
-        @Override
-        public String getActionName() {
-            return action;
-        }
     }
 }

--- a/src/test/java/com/nike/cerberus/service/CleanUpServiceTest.java
+++ b/src/test/java/com/nike/cerberus/service/CleanUpServiceTest.java
@@ -66,7 +66,7 @@ public class CleanUpServiceTest {
         cleanUpService.cleanUpInactiveAndOrphanedKmsKeys(inactivePeriod, 0);
 
         verify(awsIamRoleDao).getInactiveOrOrphanedKmsKeys(inactiveCutoffDate);
-        verify(awsIamRoleDao).deleteKmsKeyById(keyRecordId);
+        verify(kmsService).deleteKmsKeyById(keyRecordId);
         verify(kmsService).scheduleKmsKeyDeletion(awsKeyId, keyRegion, SOONEST_A_KMS_KEY_CAN_BE_DELETED);
     }
 

--- a/src/test/java/com/nike/cerberus/service/KmsPolicyServiceTest.java
+++ b/src/test/java/com/nike/cerberus/service/KmsPolicyServiceTest.java
@@ -1,8 +1,13 @@
 package com.nike.cerberus.service;
 
+import com.amazonaws.auth.policy.Action;
+import com.amazonaws.auth.policy.Policy;
+import com.amazonaws.auth.policy.Statement;
+import com.amazonaws.auth.policy.actions.KMSActions;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -46,29 +51,113 @@ public class KmsPolicyServiceTest {
         String actualPolicyJsonAsString = kmsPolicyService.generateStandardKmsPolicy(CERBERUS_CONSUMER_IAM_ROLE_ARN);
 
         assertEquals(minifiedPolicyJsonAsString, actualPolicyJsonAsString);
+
+        expectedPolicyStream.close();
     }
 
     @Test
-    public void test_that_generateStandardKmsPolicy_returns_true_with_a_valid_policy() throws IOException {
+    public void test_that_isPolicyValid_returns_true_with_a_valid_policy() throws IOException {
         InputStream policy = getClass().getClassLoader()
                 .getResourceAsStream("com/nike/cerberus/service/valid-cerberus-iam-auth-kms-key-policy.json");
         String policyJsonAsString = IOUtils.toString(policy, "UTF-8");
 
         assertTrue(kmsPolicyService.isPolicyValid(policyJsonAsString, CERBERUS_CONSUMER_IAM_ROLE_ARN));
+
+        policy.close();
     }
 
     @Test
-    public void test_that_generateStandardKmsPolicy_returns_false_with_an_invalid_policy() throws IOException {
+    public void test_that_isPolicyValid_returns_false_with_an_invalid_policy() throws IOException {
         InputStream policy = getClass().getClassLoader()
                 .getResourceAsStream("com/nike/cerberus/service/invalid-cerberus-iam-auth-kms-key-policy.json");
         String policyJsonAsString = IOUtils.toString(policy, "UTF-8");
 
         assertFalse(kmsPolicyService.isPolicyValid(policyJsonAsString, CERBERUS_CONSUMER_IAM_ROLE_ARN));
+
+        policy.close();
     }
 
     @Test
-    public void test_that_generateStandardKmsPolicy_returns_false_when_a_non_standard_policy_is_supplied() {
+    public void test_that_isPolicyValid_returns_false_when_cms_does_not_have_delete_permission() throws IOException {
+        InputStream policy = getClass().getClassLoader()
+                .getResourceAsStream("com/nike/cerberus/service/invalid-cerberus-kms-key-policy-cms-cannot-delete.json");
+        String policyJsonAsString = IOUtils.toString(policy, "UTF-8");
+
+        assertFalse(kmsPolicyService.isPolicyValid(policyJsonAsString, CERBERUS_CONSUMER_IAM_ROLE_ARN));
+
+        policy.close();
+    }
+
+    @Test
+    public void test_that_isPolicyValid_returns_false_when_a_non_standard_policy_is_supplied() {
         assertFalse(kmsPolicyService.isPolicyValid(null, CERBERUS_CONSUMER_IAM_ROLE_ARN));
     }
 
+    @Test
+    public void test_that_cmsCanScheduleKeyDeletion_returns_true_when_cms_can_delete() throws IOException {
+        InputStream policy = getClass().getClassLoader()
+                .getResourceAsStream("com/nike/cerberus/service/valid-cerberus-iam-auth-kms-key-policy.json");
+        String policyJsonAsString = IOUtils.toString(policy, "UTF-8");
+
+        assertTrue(kmsPolicyService.cmsHasKeyDeletePermissions(policyJsonAsString));
+
+        policy.close();
+    }
+
+    @Test
+    public void test_that_cmsCanScheduleKeyDeletion_returns_false_when_cms_cannot_delete() throws IOException {
+        InputStream policy = getClass().getClassLoader()
+                .getResourceAsStream("com/nike/cerberus/service/invalid-cerberus-kms-key-policy-cms-cannot-delete.json");
+        String policyJsonAsString = IOUtils.toString(policy, "UTF-8");
+
+        assertFalse(kmsPolicyService.cmsHasKeyDeletePermissions(policyJsonAsString));
+
+        policy.close();
+    }
+
+    @Test
+    public void test_that_overwriteCMSPolicy_returns_policy_that_includes_missing_actions() throws IOException {
+        InputStream policy = getClass().getClassLoader()
+                .getResourceAsStream("com/nike/cerberus/service/invalid-cerberus-kms-key-policy-cms-cannot-delete.json");
+        String policyJsonAsString = IOUtils.toString(policy, "UTF-8");
+
+        Action actionNotIncludedInInvalidJson1 = KMSActions.ScheduleKeyDeletion;
+        Action actionNotIncludedInInvalidJson2 = KMSActions.CancelKeyDeletion;
+        String result = kmsPolicyService.overwriteCMSPolicy(policyJsonAsString);
+        assertFalse(StringUtils.equals(policyJsonAsString, result));
+        assertTrue(StringUtils.contains(result, actionNotIncludedInInvalidJson1.getActionName()));
+        assertTrue(StringUtils.contains(result, actionNotIncludedInInvalidJson2.getActionName()));
+        assertTrue(kmsPolicyService.cmsHasKeyDeletePermissions(result));
+
+        policy.close();
+    }
+
+    @Test
+    public void test_that_overwriteCMSPolicy_does_not_fail_with_valid_policy() throws IOException {
+        InputStream policy = getClass().getClassLoader()
+                .getResourceAsStream("com/nike/cerberus/service/valid-cerberus-iam-auth-kms-key-policy.json");
+        String policyJsonAsString = IOUtils.toString(policy, "UTF-8");
+
+        String result = kmsPolicyService.overwriteCMSPolicy(policyJsonAsString);
+        assertFalse(StringUtils.equals(policyJsonAsString, result));
+        assertTrue(kmsPolicyService.cmsHasKeyDeletePermissions(result));
+
+        policy.close();
+    }
+
+    @Test
+    public void test_that_statementAllowsAction_returns_true_when_action_in_statement() {
+        Action action = KMSActions.CancelKeyDeletion;
+        Statement statement = new Statement(Statement.Effect.Allow).withActions(action);
+        assertTrue(kmsPolicyService.statementIncludesAction(statement, action));
+    }
+
+    @Test
+    public void test_that_generateStandardCMSPolicyStatement_returns_a_valid_statement() {
+
+        Statement result = kmsPolicyService.generateStandardCMSPolicyStatement();
+        assertEquals(KmsPolicyService.CERBERUS_MANAGEMENT_SERVICE_SID, result.getId());
+        assertEquals(Statement.Effect.Allow, result.getEffect());
+        assertTrue(kmsPolicyService.cmsHasKeyDeletePermissions(new Policy().withStatements(result).toJson()));
+    }
 }

--- a/src/test/resources/com/nike/cerberus/service/invalid-cerberus-iam-auth-kms-key-policy.json
+++ b/src/test/resources/com/nike/cerberus/service/invalid-cerberus-iam-auth-kms-key-policy.json
@@ -38,7 +38,8 @@
         "kms:Decrypt",
         "kms:ReEncrypt*",
         "kms:GenerateDataKey*",
-        "kms:DescribeKey"
+        "kms:DescribeKey",
+        "kms:ScheduleKeyDeletion"
       ],
       "Resource":[
         "*"

--- a/src/test/resources/com/nike/cerberus/service/invalid-cerberus-kms-key-policy-cms-cannot-delete.json
+++ b/src/test/resources/com/nike/cerberus/service/invalid-cerberus-kms-key-policy-cms-cannot-delete.json
@@ -36,14 +36,9 @@
       "Action":[
         "kms:Encrypt",
         "kms:Decrypt",
-        "kms:ReEncryptFrom",
-        "kms:ReEncryptTo",
-        "kms:GenerateDataKey",
-        "kms:GenerateDataKeyWithoutPlaintext",
-        "kms:GenerateRandom",
-        "kms:DescribeKey",
-        "kms:ScheduleKeyDeletion",
-        "kms:CancelKeyDeletion"
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey"
       ],
       "Resource":[
         "*"


### PR DESCRIPTION
* Updates the AWS SDK from 1.11.108 to 1.11.160
* Uses KMS Policy.toJson() + Policy.fromJson methods
* Retroactively updates KMS key policies to include new perms for CMS