### PR TITLE
Fixing hystrix exception handling

### DIFF
--- a/src/main/java/com/nike/cerberus/hystrix/HystrixKmsClient.java
+++ b/src/main/java/com/nike/cerberus/hystrix/HystrixKmsClient.java
@@ -109,7 +109,7 @@ public class HystrixKmsClient extends AWSKMSClient {
                 }
             }.execute();
         } catch (HystrixRuntimeException | HystrixBadRequestException e) {
-            LOGGER.error("commandKey: " + commandKey, e);
+            LOGGER.error("commandKey: " + commandKey);
             if (e.getCause() instanceof RuntimeException) {
                 // Convert back to the underlying exception type
                 throw (RuntimeException) e.getCause();

--- a/src/main/java/com/nike/cerberus/hystrix/HystrixKmsClient.java
+++ b/src/main/java/com/nike/cerberus/hystrix/HystrixKmsClient.java
@@ -1,7 +1,7 @@
 package com.nike.cerberus.hystrix;
 
+import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.kms.AWSKMSClient;
-import com.amazonaws.services.kms.model.AWSKMSException;
 import com.amazonaws.services.kms.model.CreateAliasRequest;
 import com.amazonaws.services.kms.model.CreateAliasResult;
 import com.amazonaws.services.kms.model.CreateKeyRequest;
@@ -98,7 +98,7 @@ public class HystrixKmsClient extends AWSKMSClient {
                 protected T run() {
                     try {
                         return function.get();
-                    } catch (AWSKMSException e) {
+                    } catch (AmazonServiceException e) {
                         if (e.getStatusCode() >= 400 && e.getStatusCode() < 500) {
                             // convert 4xx error codes to bad request
                             throw new HystrixBadRequestException(commandKey + " " + e.toString(), e);

--- a/src/main/java/com/nike/cerberus/hystrix/HystrixVaultAdminClient.java
+++ b/src/main/java/com/nike/cerberus/hystrix/HystrixVaultAdminClient.java
@@ -82,7 +82,7 @@ public class HystrixVaultAdminClient {
                 }
             }.execute();
         } catch (HystrixRuntimeException e) {
-            LOGGER.error("commandKey:" + commandKey, e);
+            LOGGER.error("commandKey:" + commandKey);
             if (e.getCause() instanceof RuntimeException) {
                 // Convert back to the underlying exception type
                 throw (RuntimeException) e.getCause();


### PR DESCRIPTION
- 4xx errors from AWS should be converted to HystrixBadRequestException
- HystrixRuntimeException and HystrixBadRequestException should be converted back to underlying exception type when possible since there is logic that depends on the underlying exception types