### PR TITLE
Use the UserGroupApi client rather than the UserApiClient so that we …

### DIFF
--- a/gradle/integration.gradle
+++ b/gradle/integration.gradle
@@ -15,20 +15,37 @@
  */
 
 sourceSets {
-    integration {
-        java.srcDir file('src/integration/java')
-        resources.srcDir file('src/integration/resources')
+    integrationTest {
+        java {
+            compileClasspath += main.output + test.output
+            runtimeClasspath += main.output + test.output
+            srcDir file('src/integration-test/java')
+        }
+        resources.srcDir file('src/integration-test/resources')
     }
 }
 
-task integration(type: Test, description: 'Runs integration tests') {
-    testClassesDir = sourceSets.integration.output.classesDir
-    classpath = sourceSets.integration.runtimeClasspath
+configurations {
+    integrationTestCompile.extendsFrom testCompile
+    integrationTestRuntime.extendsFrom testRuntime
 }
 
+task integrationTest(type: Test) {
+    testClassesDir = sourceSets.integrationTest.output.classesDir
+    classpath = sourceSets.integrationTest.runtimeClasspath
+}
+
+integrationTest {
+    testLogging {
+        showStandardStreams = true
+    }
+}
+
+
 dependencies {
-    integrationCompile sourceSets.main.output
-    integrationCompile configurations.testCompile
-    integrationCompile sourceSets.test.output
-    integrationRuntime configurations.testRuntime
+    integrationTestCompile sourceSets.main.output
+    integrationTestCompile configurations.testCompile
+    integrationTestCompile sourceSets.test.output
+    integrationTestRuntime configurations.testRuntime
+    integrationTestCompile 'com.fieldju:commons:1.1.0'
 }

--- a/src/integration-test/java/com.nike.cerberus/auth/connector/okta/OktaApiClientHelperIntegrationTest.java
+++ b/src/integration-test/java/com.nike.cerberus/auth/connector/okta/OktaApiClientHelperIntegrationTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2017 Nike, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nike.cerberus.auth.connector.okta;
+
+import com.fieldju.commons.EnvUtils;
+import com.okta.sdk.clients.AuthApiClient;
+import com.okta.sdk.clients.FactorsApiClient;
+import com.okta.sdk.clients.UserGroupApiClient;
+import com.okta.sdk.framework.ApiClientConfiguration;
+import com.okta.sdk.models.usergroups.UserGroup;
+import okhttp3.OkHttpClient;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+public class OktaApiClientHelperIntegrationTest {
+
+    AuthApiClient authClient;
+    UserGroupApiClient userApiClient;
+    FactorsApiClient factorsApiClient;
+
+    OktaApiClientHelper oktaApiClientHelper;
+
+    @Before
+    public void before() {
+        String oktaApiKey = EnvUtils.getRequiredEnv("OKTA_API_KEY", "The okta api key");
+        String oktaApiUrl = EnvUtils.getRequiredEnv("OKTA_API_URL", "The okta api url");
+
+        final ApiClientConfiguration clientConfiguration = new ApiClientConfiguration(oktaApiUrl, oktaApiKey);
+
+        authClient = spy(new AuthApiClient(clientConfiguration));
+        userApiClient = spy(new UserGroupApiClient(clientConfiguration));
+        factorsApiClient = spy(new FactorsApiClient(clientConfiguration));
+
+        oktaApiClientHelper = new OktaApiClientHelper(authClient, userApiClient, factorsApiClient, oktaApiUrl);
+    }
+
+
+    @Test
+    public void test_that_getUserGroups_can_handle_pagination() throws IOException {
+        String userIdForUserWithMoreThan1Group = EnvUtils.getRequiredEnv("OKTA_USER",
+                "Provide a user id for a user with more than 1 groups");
+
+        OktaApiClientHelper oktaApiClientHelperSpy = spy(oktaApiClientHelper);
+
+        List<UserGroup> userGroups = oktaApiClientHelperSpy.getUserGroups(userIdForUserWithMoreThan1Group, 1);
+        assertTrue("The user group list should have more than 1 group in it", userGroups.size() > 1);
+        verify(userApiClient, atLeast(2)).getUserGroupsPagedResultsByUrl(anyString());
+    }
+
+}

--- a/src/main/java/com/nike/cerberus/auth/connector/okta/OktaApiClientHelper.java
+++ b/src/main/java/com/nike/cerberus/auth/connector/okta/OktaApiClientHelper.java
@@ -23,46 +23,55 @@ import com.nike.backstopper.exception.ApiException;
 import com.nike.cerberus.error.DefaultApiError;
 import com.okta.sdk.clients.AuthApiClient;
 import com.okta.sdk.clients.FactorsApiClient;
-import com.okta.sdk.clients.UserApiClient;
+import com.okta.sdk.clients.UserGroupApiClient;
 import com.okta.sdk.framework.ApiClientConfiguration;
+import com.okta.sdk.framework.PagedResults;
 import com.okta.sdk.models.auth.AuthResult;
 import com.okta.sdk.models.factors.Factor;
 import com.okta.sdk.models.usergroups.UserGroup;
 
 import javax.inject.Named;
 import java.io.IOException;
+import java.util.LinkedList;
 import java.util.List;
 
 /**
  * Helper methods to authenticate with Okta.
  */
+@SuppressWarnings("CdiManagedBeanInconsistencyInspection")
 public class OktaApiClientHelper {
 
     private final AuthApiClient authClient;
 
-    private final UserApiClient userApiClient;
+    private final UserGroupApiClient userGroupApiClient;
 
     private final FactorsApiClient factorsApiClient;
 
-    protected OktaApiClientHelper(final AuthApiClient authClient,
-                                  final UserApiClient userApiClient,
-                                  final FactorsApiClient factorsApiClient) {
+    private final String baseUrl;
+
+    protected OktaApiClientHelper(AuthApiClient authClient,
+                                  UserGroupApiClient userGroupApiClient,
+                                  FactorsApiClient factorsApiClient,
+                                  String baseUrl) {
 
         this.authClient = authClient;
-        this.userApiClient = userApiClient;
+        this.userGroupApiClient = userGroupApiClient;
         this.factorsApiClient = factorsApiClient;
+        this.baseUrl = baseUrl;
     }
 
     @Inject
-    public OktaApiClientHelper(@Named("auth.connector.okta.api_key") final String oktaApiKey,
-                               @Named("auth.connector.okta.base_url") final String baseUrl) {
+    public OktaApiClientHelper(@Named("auth.connector.okta.api_key") String oktaApiKey,
+                               @Named("auth.connector.okta.base_url") String baseUrl) {
 
         Preconditions.checkArgument(oktaApiKey != null, "okta api key cannot be null");
         Preconditions.checkArgument(baseUrl != null, "okta base url cannot be null");
 
+        this.baseUrl = baseUrl;
+
         final ApiClientConfiguration clientConfiguration = new ApiClientConfiguration(baseUrl, oktaApiKey);
         authClient = new AuthApiClient(clientConfiguration);
-        userApiClient = new UserApiClient(clientConfiguration);
+        userGroupApiClient = new UserGroupApiClient(clientConfiguration);
         factorsApiClient = new FactorsApiClient(clientConfiguration);
     }
 
@@ -73,9 +82,41 @@ public class OktaApiClientHelper {
      * @return User groups
      */
     protected List<UserGroup> getUserGroups(final String userId) {
+        return getUserGroups(userId, null);
+    }
 
+    /**
+     * Request to get user group data by the user's ID.
+     *
+     * @param userId User ID
+     * @param limit The page size limit, if null the default will be used
+     * @return User groups
+     */
+    protected List<UserGroup> getUserGroups(String userId, Integer limit) {
+        List<UserGroup> userGroups = new LinkedList<>();
         try {
-            return userApiClient.getUserGroups(userId);
+            boolean hasNext;
+            StringBuilder urlBuilder = new StringBuilder(baseUrl)
+                    .append("/api/v1/users/").append(userId).append("/groups");
+
+            if (limit != null) {
+                urlBuilder.append("?limit=").append(limit);
+            }
+            String url = urlBuilder.toString();
+
+            do {
+                PagedResults<UserGroup> userGroupPagedResults = userGroupApiClient
+                        .getUserGroupsPagedResultsByUrl(url);
+
+                userGroups.addAll(userGroupPagedResults.getResult());
+
+                if (! userGroupPagedResults.isLastPage()) {
+                    hasNext = true;
+                    url = userGroupPagedResults.getNextUrl();
+                } else {
+                    hasNext = false;
+                }
+            } while (hasNext);
         } catch (IOException ioe) {
             final String msg = String.format("failed to get user groups for user (%s) for reason: %s", userId,
                     ioe.getMessage());
@@ -85,6 +126,7 @@ public class OktaApiClientHelper {
                     .withExceptionMessage(msg)
                     .build();
         }
+        return userGroups;
     }
 
     /**

--- a/src/main/java/com/nike/cerberus/auth/connector/okta/OktaAuthConnector.java
+++ b/src/main/java/com/nike/cerberus/auth/connector/okta/OktaAuthConnector.java
@@ -108,7 +108,7 @@ public class OktaAuthConnector implements AuthConnector {
         final List<UserGroup> userGroups = oktaApiClientHelper.getUserGroups(authData.getUserId());
 
         final Set<String> groups = new HashSet<>();
-        if (userGroups == null) {
+        if (userGroups.isEmpty()) {
             return groups;
         }
 

--- a/src/main/java/com/nike/cerberus/auth/connector/okta/OktaMFAAuthConnector.java
+++ b/src/main/java/com/nike/cerberus/auth/connector/okta/OktaMFAAuthConnector.java
@@ -104,7 +104,7 @@ public class OktaMFAAuthConnector implements AuthConnector {
         final List<UserGroup> userGroups = oktaApiClientHelper.getUserGroups(authData.getUserId());
 
         final Set<String> groups = new HashSet<>();
-        if (userGroups == null) {
+        if (userGroups.isEmpty()) {
             return groups;
         }
 

--- a/src/test/java/com/nike/cerberus/auth/connector/okta/OktaApiClientHelperTest.java
+++ b/src/test/java/com/nike/cerberus/auth/connector/okta/OktaApiClientHelperTest.java
@@ -22,6 +22,8 @@ import com.nike.backstopper.exception.ApiException;
 import com.okta.sdk.clients.AuthApiClient;
 import com.okta.sdk.clients.FactorsApiClient;
 import com.okta.sdk.clients.UserApiClient;
+import com.okta.sdk.clients.UserGroupApiClient;
+import com.okta.sdk.framework.PagedResults;
 import com.okta.sdk.models.auth.AuthResult;
 import com.okta.sdk.models.usergroups.UserGroup;
 import org.junit.Before;
@@ -52,7 +54,7 @@ public class OktaApiClientHelperTest {
     private AuthApiClient authApiClient;
 
     @Mock
-    private UserApiClient userApiClient;
+    private UserGroupApiClient userGroupApiClient;
 
     @Mock
     private FactorsApiClient factorsApiClient;
@@ -63,7 +65,7 @@ public class OktaApiClientHelperTest {
         initMocks(this);
 
         // create test object
-        this.oktaApiClientHelper = new OktaApiClientHelper(authApiClient, userApiClient, factorsApiClient);
+        this.oktaApiClientHelper = new OktaApiClientHelper(authApiClient, userGroupApiClient, factorsApiClient, "");
     }
 
 
@@ -76,7 +78,10 @@ public class OktaApiClientHelperTest {
 
         String id = "id";
         UserGroup group = mock(UserGroup.class);
-        when(userApiClient.getUserGroups(id)).thenReturn(Lists.newArrayList(group));
+        PagedResults res = mock(PagedResults.class);
+        when(res.getResult()).thenReturn(Lists.newArrayList(group));
+        when(res.isLastPage()).thenReturn(true);
+        when(userGroupApiClient.getUserGroupsPagedResultsByUrl(anyString())).thenReturn(res);
 
         // do the call
         List<UserGroup> result = this.oktaApiClientHelper.getUserGroups(id);
@@ -88,7 +93,7 @@ public class OktaApiClientHelperTest {
     @Test(expected = ApiException.class)
     public void getUserGroupsFails() throws Exception {
 
-        when(userApiClient.getUserGroups(anyString())).thenThrow(IOException.class);
+        when(userGroupApiClient.getUserGroupsPagedResultsByUrl(anyString())).thenThrow(IOException.class);
 
         // do the call
         this.oktaApiClientHelper.getUserGroups("id");


### PR DESCRIPTION
…can paginate over user groups when a user belongs to a large number of groups