### PR TITLE
Updating ARN validation to reject instance-profile ARNs 

### DIFF
--- a/src/main/java/com/nike/cerberus/util/AwsIamRoleArnParser.java
+++ b/src/main/java/com/nike/cerberus/util/AwsIamRoleArnParser.java
@@ -30,7 +30,7 @@ public class AwsIamRoleArnParser {
 
     public static final String AWS_IAM_ROLE_ARN_TEMPLATE = "arn:aws:iam::%s:role/%s";
 
-    public static final String AWS_IAM_PRINCIPAL_ARN_REGEX = "^arn:aws:(iam|sts)::(?<accountId>\\d+?):(?!group).+?/(?<roleName>.+)$";
+    public static final String AWS_IAM_PRINCIPAL_ARN_REGEX = "^arn:aws:(iam|sts)::(?<accountId>\\d+?):(role|user|federated-user|assumed-role).*?/(?<roleName>.+)$";
 
     private static final String AWS_IAM_ROLE_ARN_REGEX = "^arn:aws:iam::(?<accountId>\\d+?):role/(?<roleName>.+)$";
 
@@ -38,7 +38,7 @@ public class AwsIamRoleArnParser {
 
     private static final String GENERIC_ASSUMED_ROLE_REGEX = "^arn:aws:sts::(?<accountId>\\d+?):assumed-role/.+$";
 
-    private static final Pattern IAM_PRINCIPAL_ARN_PATTERN = Pattern.compile(AWS_IAM_PRINCIPAL_ARN_REGEX);
+    public static final Pattern IAM_PRINCIPAL_ARN_PATTERN = Pattern.compile(AWS_IAM_PRINCIPAL_ARN_REGEX);
 
     private static final Pattern IAM_ROLE_ARN_PATTERN = Pattern.compile(AWS_IAM_ROLE_ARN_REGEX);
 

--- a/src/test/java/com/nike/cerberus/util/AwsIamRoleArnParserTest.java
+++ b/src/test/java/com/nike/cerberus/util/AwsIamRoleArnParserTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static com.nike.cerberus.util.AwsIamRoleArnParser.IAM_PRINCIPAL_ARN_PATTERN;
 import static org.junit.Assert.assertEquals;
 
 import static org.junit.Assert.assertFalse;
@@ -103,5 +104,35 @@ public class AwsIamRoleArnParserTest {
         assertFalse(awsIamRoleArnParser.isRoleArn("arn:aws:iam::3333333333:assumed-role/happy/path"));
         assertFalse(awsIamRoleArnParser.isRoleArn("arn:aws:sts::1111111111:federated-user/my_user"));
         assertFalse(awsIamRoleArnParser.isRoleArn("arn:aws:iam::1111111111:group/path/to/group"));
+    }
+
+    @Test
+    public void test_IAM_PRINCIPAL_ARN_PATTERN_valid_ARNs_accepted_by_KMS() {
+        // valid
+        assertTrue(IAM_PRINCIPAL_ARN_PATTERN.matcher("arn:aws:iam::12345678901234:role/some-role").matches());
+        assertTrue(IAM_PRINCIPAL_ARN_PATTERN.matcher("arn:aws:iam::12345678901234:role/some/path/some-role").matches());
+        assertTrue(IAM_PRINCIPAL_ARN_PATTERN.matcher("arn:aws:iam::12345678901234:user/some-user").matches());
+        assertTrue(IAM_PRINCIPAL_ARN_PATTERN.matcher("arn:aws:sts::12345678901234:assumed-role/some-path/some-role").matches());
+        assertTrue(IAM_PRINCIPAL_ARN_PATTERN.matcher("arn:aws:sts::12345678901234:assumed-role/some-role").matches());
+        assertTrue(IAM_PRINCIPAL_ARN_PATTERN.matcher("arn:aws:sts::12345678901234:federated-user/my_user").matches());
+    }
+
+    @Test
+    public void test_IAM_PRINCIPAL_ARN_PATTERN_valid_ARNs_rejected_by_KMS() {
+        // invalid - KMS doesn't allow 'group' or 'instance-profile'
+        assertFalse(IAM_PRINCIPAL_ARN_PATTERN.matcher("arn:aws:iam::12345678901234:group/some-group").matches());
+        assertFalse(IAM_PRINCIPAL_ARN_PATTERN.matcher("arn:aws:iam::12345678901234:instance-profile/some-profile").matches());
+        assertFalse(IAM_PRINCIPAL_ARN_PATTERN.matcher("arn:aws:iam::12345678901234:other/some-value").matches());
+    }
+
+    @Test
+    public void test_IAM_PRINCIPAL_ARN_PATTERN_invalid_ARNs() {
+        assertFalse(IAM_PRINCIPAL_ARN_PATTERN.matcher("arn:aws:iam::12345678901234:some-role").matches());
+        assertFalse(IAM_PRINCIPAL_ARN_PATTERN.matcher("arn:aws:iam:::role/some-role").matches());
+        assertFalse(IAM_PRINCIPAL_ARN_PATTERN.matcher("arn:aws:::12345678901234:role/some-role").matches());
+        assertFalse(IAM_PRINCIPAL_ARN_PATTERN.matcher("arn:aws:iam::12345678901234:").matches());
+        assertFalse(IAM_PRINCIPAL_ARN_PATTERN.matcher("arn::iam::12345678901234:role/some-role").matches());
+        assertFalse(IAM_PRINCIPAL_ARN_PATTERN.matcher(":aws:iam::12345678901234:role/some-role").matches());
+        assertFalse(IAM_PRINCIPAL_ARN_PATTERN.matcher("arn:aws:iam::12345678901234:other/some-value").matches());
     }
 }


### PR DESCRIPTION
Updating ARN validation to reject instance-profile ARNs because KMS policies reject them