### PR TITLE
Bug fixes: key policy validation and ARN validation

### DIFF
--- a/src/main/java/com/nike/cerberus/domain/IamPrincipalCredentials.java
+++ b/src/main/java/com/nike/cerberus/domain/IamPrincipalCredentials.java
@@ -21,14 +21,14 @@ import org.hibernate.validator.constraints.NotBlank;
 
 import javax.validation.constraints.Pattern;
 
-import static com.nike.cerberus.util.AwsIamRoleArnParser.AWS_IAM_PRINCIPAL_ARN_REGEX;
+import static com.nike.cerberus.util.AwsIamRoleArnParser.AWS_IAM_PRINCIPAL_ARN_REGEX_ALLOWED;
 
 /**
  * Represents the IAM principal credentials sent during authentication.
  */
 public class IamPrincipalCredentials {
 
-    @Pattern(regexp = AWS_IAM_PRINCIPAL_ARN_REGEX, message = "AUTH_IAM_PRINCIPAL_INVALID")
+    @Pattern(regexp = AWS_IAM_PRINCIPAL_ARN_REGEX_ALLOWED, message = "AUTH_IAM_PRINCIPAL_INVALID")
     private String iamPrincipalArn;
 
     @NotBlank(message = "AUTH_IAM_PRINCIPAL_AWS_REGION_BLANK")

--- a/src/main/java/com/nike/cerberus/domain/IamPrincipalPermission.java
+++ b/src/main/java/com/nike/cerberus/domain/IamPrincipalPermission.java
@@ -24,7 +24,7 @@ import javax.validation.constraints.Pattern;
 import javax.validation.groups.Default;
 import java.time.OffsetDateTime;
 
-import static com.nike.cerberus.util.AwsIamRoleArnParser.AWS_IAM_PRINCIPAL_ARN_REGEX;
+import static com.nike.cerberus.util.AwsIamRoleArnParser.AWS_IAM_PRINCIPAL_ARN_REGEX_ALLOWED;
 
 /**
  * Represents a permission granted to an IAM role with regards to a safe deposit box
@@ -36,7 +36,7 @@ public class IamPrincipalPermission {
     @NotBlank(message = "IAM_ROLE_ROLE_ID_INVALID", groups = {Default.class, Updatable.class})
     private String roleId;
 
-    @Pattern(regexp = AWS_IAM_PRINCIPAL_ARN_REGEX, message = "SDB_IAM_PRINCIPAL_PERMISSION_ARN_INVALID", groups = {Default.class, Updatable.class})
+    @Pattern(regexp = AWS_IAM_PRINCIPAL_ARN_REGEX_ALLOWED, message = "SDB_IAM_PRINCIPAL_PERMISSION_ARN_INVALID", groups = {Default.class, Updatable.class})
     private String iamPrincipalArn;
 
     private OffsetDateTime createdTs;

--- a/src/main/java/com/nike/cerberus/service/KmsPolicyService.java
+++ b/src/main/java/com/nike/cerberus/service/KmsPolicyService.java
@@ -112,7 +112,7 @@ public class KmsPolicyService {
                             StringUtils.equals(statement.getId(), CERBERUS_CONSUMER_SID) &&
                                     statement.getPrincipals()
                                             .stream()
-                                            .anyMatch(principal -> awsIamRoleArnParser.isRoleArn(principal.getId())));
+                                            .anyMatch(principal -> awsIamRoleArnParser.isArnThatCanGoInKeyPolicy(principal.getId())));
         } catch (Exception e) {
             // if we can't deserialize we will assume policy has been corrupted manually and regenerate it
             logger.error("Failed to validate policy, did someone manually edit the kms policy?", e);

--- a/src/test/java/com/nike/cerberus/util/AwsIamRoleArnParserTest.java
+++ b/src/test/java/com/nike/cerberus/util/AwsIamRoleArnParserTest.java
@@ -20,16 +20,11 @@ package com.nike.cerberus.util;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import static com.nike.cerberus.util.AwsIamRoleArnParser.IAM_PRINCIPAL_ARN_PATTERN;
+import static com.nike.cerberus.util.AwsIamRoleArnParser.IAM_PRINCIPAL_ARN_PATTERN_ALLOWED;
 import static org.junit.Assert.assertEquals;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * Tests the AwsIamRoleArnParser class
@@ -109,30 +104,45 @@ public class AwsIamRoleArnParserTest {
     @Test
     public void test_IAM_PRINCIPAL_ARN_PATTERN_valid_ARNs_accepted_by_KMS() {
         // valid
-        assertTrue(IAM_PRINCIPAL_ARN_PATTERN.matcher("arn:aws:iam::12345678901234:role/some-role").matches());
-        assertTrue(IAM_PRINCIPAL_ARN_PATTERN.matcher("arn:aws:iam::12345678901234:role/some/path/some-role").matches());
-        assertTrue(IAM_PRINCIPAL_ARN_PATTERN.matcher("arn:aws:iam::12345678901234:user/some-user").matches());
-        assertTrue(IAM_PRINCIPAL_ARN_PATTERN.matcher("arn:aws:sts::12345678901234:assumed-role/some-path/some-role").matches());
-        assertTrue(IAM_PRINCIPAL_ARN_PATTERN.matcher("arn:aws:sts::12345678901234:assumed-role/some-role").matches());
-        assertTrue(IAM_PRINCIPAL_ARN_PATTERN.matcher("arn:aws:sts::12345678901234:federated-user/my_user").matches());
+        assertTrue(IAM_PRINCIPAL_ARN_PATTERN_ALLOWED.matcher("arn:aws:iam::12345678901234:role/some-role").matches());
+        assertTrue(IAM_PRINCIPAL_ARN_PATTERN_ALLOWED.matcher("arn:aws:iam::12345678901234:role/some/path/some-role").matches());
+        assertTrue(IAM_PRINCIPAL_ARN_PATTERN_ALLOWED.matcher("arn:aws:iam::12345678901234:user/some-user").matches());
+        assertTrue(IAM_PRINCIPAL_ARN_PATTERN_ALLOWED.matcher("arn:aws:sts::12345678901234:assumed-role/some-path/some-role").matches());
+        assertTrue(IAM_PRINCIPAL_ARN_PATTERN_ALLOWED.matcher("arn:aws:sts::12345678901234:assumed-role/some-role").matches());
+        assertTrue(IAM_PRINCIPAL_ARN_PATTERN_ALLOWED.matcher("arn:aws:sts::12345678901234:federated-user/my_user").matches());
     }
 
     @Test
     public void test_IAM_PRINCIPAL_ARN_PATTERN_valid_ARNs_rejected_by_KMS() {
         // invalid - KMS doesn't allow 'group' or 'instance-profile'
-        assertFalse(IAM_PRINCIPAL_ARN_PATTERN.matcher("arn:aws:iam::12345678901234:group/some-group").matches());
-        assertFalse(IAM_PRINCIPAL_ARN_PATTERN.matcher("arn:aws:iam::12345678901234:instance-profile/some-profile").matches());
-        assertFalse(IAM_PRINCIPAL_ARN_PATTERN.matcher("arn:aws:iam::12345678901234:other/some-value").matches());
+        assertFalse(IAM_PRINCIPAL_ARN_PATTERN_ALLOWED.matcher("arn:aws:iam::12345678901234:group/some-group").matches());
+        assertFalse(IAM_PRINCIPAL_ARN_PATTERN_ALLOWED.matcher("arn:aws:iam::12345678901234:instance-profile/some-profile").matches());
+        assertFalse(IAM_PRINCIPAL_ARN_PATTERN_ALLOWED.matcher("arn:aws:iam::12345678901234:other/some-value").matches());
     }
 
     @Test
     public void test_IAM_PRINCIPAL_ARN_PATTERN_invalid_ARNs() {
-        assertFalse(IAM_PRINCIPAL_ARN_PATTERN.matcher("arn:aws:iam::12345678901234:some-role").matches());
-        assertFalse(IAM_PRINCIPAL_ARN_PATTERN.matcher("arn:aws:iam:::role/some-role").matches());
-        assertFalse(IAM_PRINCIPAL_ARN_PATTERN.matcher("arn:aws:::12345678901234:role/some-role").matches());
-        assertFalse(IAM_PRINCIPAL_ARN_PATTERN.matcher("arn:aws:iam::12345678901234:").matches());
-        assertFalse(IAM_PRINCIPAL_ARN_PATTERN.matcher("arn::iam::12345678901234:role/some-role").matches());
-        assertFalse(IAM_PRINCIPAL_ARN_PATTERN.matcher(":aws:iam::12345678901234:role/some-role").matches());
-        assertFalse(IAM_PRINCIPAL_ARN_PATTERN.matcher("arn:aws:iam::12345678901234:other/some-value").matches());
+        assertFalse(IAM_PRINCIPAL_ARN_PATTERN_ALLOWED.matcher("arn:aws:iam::12345678901234:some-role").matches());
+        assertFalse(IAM_PRINCIPAL_ARN_PATTERN_ALLOWED.matcher("arn:aws:iam:::role/some-role").matches());
+        assertFalse(IAM_PRINCIPAL_ARN_PATTERN_ALLOWED.matcher("arn:aws:::12345678901234:role/some-role").matches());
+        assertFalse(IAM_PRINCIPAL_ARN_PATTERN_ALLOWED.matcher("arn:aws:iam::12345678901234:").matches());
+        assertFalse(IAM_PRINCIPAL_ARN_PATTERN_ALLOWED.matcher("arn::iam::12345678901234:role/some-role").matches());
+        assertFalse(IAM_PRINCIPAL_ARN_PATTERN_ALLOWED.matcher(":aws:iam::12345678901234:role/some-role").matches());
+        assertFalse(IAM_PRINCIPAL_ARN_PATTERN_ALLOWED.matcher("arn:aws:iam::12345678901234:other/some-value").matches());
+    }
+
+    @Test
+    public void test_isArnThatCanGoInKeyPolicy() {
+        assertTrue(awsIamRoleArnParser.isArnThatCanGoInKeyPolicy("arn:aws:iam::12345678901234:role/some-role"));
+        assertTrue(awsIamRoleArnParser.isArnThatCanGoInKeyPolicy("arn:aws:iam::12345678901234:role/some/path/some-role"));
+        assertTrue(awsIamRoleArnParser.isArnThatCanGoInKeyPolicy("arn:aws:iam::12345678901234:user/some-user"));
+        assertTrue(awsIamRoleArnParser.isArnThatCanGoInKeyPolicy("arn:aws:sts::12345678901234:assumed-role/some-path/some-role"));
+        assertTrue(awsIamRoleArnParser.isArnThatCanGoInKeyPolicy("arn:aws:sts::12345678901234:assumed-role/some-role"));
+        assertTrue(awsIamRoleArnParser.isArnThatCanGoInKeyPolicy("arn:aws:sts::12345678901234:federated-user/my_user"));
+
+        // invalid - KMS doesn't allow 'group' or 'instance-profile'
+        assertFalse(awsIamRoleArnParser.isArnThatCanGoInKeyPolicy("arn:aws:iam::12345678901234:group/some-group"));
+        assertFalse(awsIamRoleArnParser.isArnThatCanGoInKeyPolicy("arn:aws:iam::12345678901234:instance-profile/some-profile"));
+        assertFalse(awsIamRoleArnParser.isArnThatCanGoInKeyPolicy("arn:aws:iam::12345678901234:other/some-value"));
     }
 }


### PR DESCRIPTION
1. key policy validation was checking for ARNs that aren't allowed in keys.
2. ARN validation in previous commit broke instance-profile ARNs that could be converted to role ARNs