### PR TITLE
Prevent wrong CMS AMI from being deployed

### DIFF
--- a/src/main/resources/com/nike/cerberus/migration/V1.5.0.0__intentional_incompatible_change.sql
+++ b/src/main/resources/com/nike/cerberus/migration/V1.5.0.0__intentional_incompatible_change.sql
@@ -1,0 +1,15 @@
+#
+# This is a dummy migration script.  It is was created to introduce an intentional incompatible
+# change in the database between the new and old Cerberus architecture.  This will cause CMS deployment
+# to fail if someone simply tries to deploy the next generation of a CMS AMI over the previous
+# generation instead of using the correct migration path (e.g. standing up a whole new environment,
+# copying the data over, updating DNS).
+#
+# For local development, you can get past the introduced issue by dropping all of your data with the
+# gradle command `./gradlew flywayClean`.
+#
+# More here:
+# https://flywaydb.org/documentation/gradle/
+#
+# Next generation of Cerberus architecture being released in 2018.
+#

--- a/src/main/resources/com/nike/cerberus/migration/V1.5.0.0__intentional_incompatible_change.sql
+++ b/src/main/resources/com/nike/cerberus/migration/V1.5.0.0__intentional_incompatible_change.sql
@@ -1,5 +1,5 @@
 #
-# This is a dummy migration script.  It is was created to introduce an intentional incompatible
+# This is a dummy migration script.  It was created to introduce an intentional incompatible
 # change in the database between the new and old Cerberus architecture.  This will cause CMS deployment
 # to fail if someone simply tries to deploy the next generation of a CMS AMI over the previous
 # generation instead of using the correct migration path (e.g. standing up a whole new environment,


### PR DESCRIPTION
* Adding intentional incompatible migration script to protect against accidentally deploying the wrong CMS AMI in the wrong environment.