### PR TITLE
Validate and silently fail on KMS alias creation

### DIFF
--- a/src/main/java/com/nike/cerberus/util/Slugger.java
+++ b/src/main/java/com/nike/cerberus/util/Slugger.java
@@ -16,6 +16,8 @@
 
 package com.nike.cerberus.util;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.text.Normalizer;
 import java.util.Locale;
 import java.util.regex.Pattern;
@@ -34,5 +36,9 @@ public class Slugger {
         final String normalized = Normalizer.normalize(nowhitespace, Normalizer.Form.NFD);
         final String slug = NONLATIN.matcher(normalized).replaceAll("");
         return slug.toLowerCase(Locale.ENGLISH);
+    }
+
+    public String slugifyKmsAliases(String input) {
+        return StringUtils.replacePattern(input, "[^a-zA-Z0-9:/_-]+", "-");
     }
 }

--- a/src/test/java/com/nike/cerberus/service/KmsServiceTest.java
+++ b/src/test/java/com/nike/cerberus/service/KmsServiceTest.java
@@ -19,6 +19,7 @@ import com.nike.cerberus.dao.AwsIamRoleDao;
 import com.nike.cerberus.record.AwsIamRoleKmsKeyRecord;
 import com.nike.cerberus.util.AwsIamRoleArnParser;
 import com.nike.cerberus.util.DateTimeSupplier;
+import com.nike.cerberus.util.Slugger;
 import com.nike.cerberus.util.UuidSupplier;
 import org.junit.Before;
 import org.junit.Test;
@@ -47,6 +48,7 @@ public class KmsServiceTest {
     private KmsClientFactory kmsClientFactory;
     private KmsPolicyService kmsPolicyService;
     private DateTimeSupplier dateTimeSupplier;
+    private Slugger slugger;
 
     private KmsService kmsService;
 
@@ -57,8 +59,9 @@ public class KmsServiceTest {
         kmsClientFactory = mock(KmsClientFactory.class);
         kmsPolicyService = mock(KmsPolicyService.class);
         dateTimeSupplier = mock(DateTimeSupplier.class);
+        slugger = new Slugger();
 
-        kmsService = new KmsService(awsIamRoleDao, uuidSupplier, kmsClientFactory, kmsPolicyService, dateTimeSupplier, new AwsIamRoleArnParser(), VERSION, ENV);
+        kmsService = new KmsService(awsIamRoleDao, uuidSupplier, kmsClientFactory, kmsPolicyService, dateTimeSupplier, new AwsIamRoleArnParser(), VERSION, ENV, slugger);
     }
 
     @Test

--- a/src/test/java/com/nike/cerberus/util/SluggerTest.java
+++ b/src/test/java/com/nike/cerberus/util/SluggerTest.java
@@ -20,6 +20,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 
 public class SluggerTest {
 
@@ -36,5 +37,11 @@ public class SluggerTest {
         final String expected = "eternal-testing";
 
         assertThat(subject.toSlug(testCase)).isEqualTo(expected);
+    }
+
+    @Test
+    public void test_sluggify_kms_alias() {
+        assertEquals("x-y-z", subject.slugifyKmsAliases("x.y.z"));
+        assertEquals("accountId/role-name", subject.slugifyKmsAliases("accountId/role.name"));
     }
 }


### PR DESCRIPTION
Fix an issue where KMS key aliases cannot be created for roles with "." in the name.

Also, silently fail on KMS key alias creation.