### PR TITLE
Feature/audit logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ cms.auth.token.hash.salt                            | Yes      | The string valu
 cms.encryption.cmk.arns                             | Yes      | Development AWS KMS CMK ARNs for use in local encryption of secrets
 cms.event.processors.com.nike.cerberus.event.processor.LoggingEventProcessor | No | defaults to true, Boolean of whether or not to enable event logging, see #events below
 cms.event.processors.com.nike.cerberus.event.processor.AuditLogProcessor | No | defaults to false, Boolean of whether or not to enable audit logging, see #events below
-cms.audit.bucket="bucket-name" | No | see Logging Event Processor below
-cms.audit.bucket_region="bucket-region" | No | see Logging Event Processor below
+cms.audit.bucket="bucket-name" | No | [See Logging Event Processor below](https://github.com/Nike-Inc/cerberus-management-service/tree/feature/audit_logging#audit-log-processor)
+cms.audit.bucket_region="bucket-region" | No | [See Logging Event Processor below](https://github.com/Nike-Inc/cerberus-management-service/tree/feature/audit_logging#audit-log-processor)
 
 KMS Policies are bound to IAM Principal IDs rather than ARNs themselves. Because of this, we validate the policy at authentication time
 to ensure that if an IAM role has been deleted and re-created, that we grant access to the new principal ID.
@@ -103,8 +103,8 @@ This event processor is on by default and takes any event and call asString() an
 
 #### Audit Log Processor
 
-This event processor is special, as when it is enable a custom logback appender is created that logs Auditable Events as flattened JSON to [HOSTNAME]-audit.log
-These files are rolled every 5 minutes and if the following -P props are set (cms.audit.bucket="bucket-name", cms.audit.bucket_region="bucket-region"), they will be sent to S3 every time they are rolled.
+This event processor is special, as when it is enable a custom logback appender is created that logs Auditable Events as flattened JSON to `[HOSTNAME]-audit.log`
+These files are rolled every 5 minutes and if the following `-P` props are set `cms.audit.bucket="bucket-name", cms.audit.bucket_region="bucket-region"`, they will be sent to S3 every time they are rolled.
 The way they are stored as flattened JSON and stored in S3 has been optimized to be used with AWS Athena so that queries can be made against the audit data.
 
 The CLI has commands for creating the S3 Buckets, IAM Roles and permissions and setting up Athena and auto-populating the properties needed to enable.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ cms.iam.token.ttl                                   | No       | By default IAM 
 cms.kms.policy.validation.interval.millis.override  | No       | By default CMS validates KMS key policies no more than once per minute, you can override that with this param
 cms.auth.token.hash.salt                            | Yes      | The string value which CMS will use to salt auth tokens
 cms.encryption.cmk.arns                             | Yes      | Development AWS KMS CMK ARNs for use in local encryption of secrets
+cms.event.processors.com.nike.cerberus.event.processor.LoggingEventProcessor | No | defaults to true, Boolean of whether or not to enable event logging, see #events below
+cms.event.processors.com.nike.cerberus.event.processor.AuditLogProcessor | No | defaults to false, Boolean of whether or not to enable audit logging, see #events below
+cms.audit.bucket="bucket-name" | No | see Logging Event Processor below
+cms.audit.bucket_region="bucket-region" | No | see Logging Event Processor below
 
 KMS Policies are bound to IAM Principal IDs rather than ARNs themselves. Because of this, we validate the policy at authentication time
 to ensure that if an IAM role has been deleted and re-created, that we grant access to the new principal ID.
@@ -76,6 +80,36 @@ For deployed environments they are configured via the CLI, which will generate a
 See [Creating an environment](http://engineering.nike.com/cerberus/docs/administration-guide/creating-an-environment) for more information.
 
 CMS will download the props file at startup time and load the props into Guice.
+
+### Events
+
+Currently there is one event type, an Auditable Event, this is an event such as a user logging in successfully or failing to login.
+
+
+See [AuditableEvent](https://github.com/Nike-Inc/cerberus-management-service/blob/master/src/main/java/com/nike/cerberus/event/AuditableEvent.java) for more information like the type of metadata that is collected about an event.
+
+These events are generated all over the system when a un-authenticated or authenticated principal does anything worth auditing. These events are sent to all registered event processors.
+There are 2 processors included by default the Logging Event Processor and the Audit Log Processor see below for more information
+
+### Event Processors
+
+Event processors can be enabled or disabled via the CLI generated configuration -P parameters see above for more information.
+in the default configuration the Logging Event Process is set to `cms.event.processors.com.nike.cerberus.event.processor.LoggingEventProcessor=true` and therefore enabled by default.
+The convention for enabling or disabling a processor is cms.event.processors.[CLASS PATH TO PROCESSOR]=true|false, guice will then attempt to create an instace of the class at runtime.
+
+#### Logging Event Processor
+
+This event processor is on by default and takes any event and call asString() and logs it.
+
+#### Audit Log Processor
+
+This event processor is special, as when it is enable a custom logback appender is created that logs Auditable Events as flattened JSON to [HOSTNAME]-audit.log
+These files are rolled every 5 minutes and if the following -P props are set (cms.audit.bucket="bucket-name", cms.audit.bucket_region="bucket-region"), they will be sent to S3 every time they are rolled.
+The way they are stored as flattened JSON and stored in S3 has been optimized to be used with AWS Athena so that queries can be made against the audit data.
+
+The CLI has commands for creating the S3 Buckets, IAM Roles and permissions and setting up Athena and auto-populating the properties needed to enable.
+
+
 
 ### User Authentication
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,6 +14,6 @@
 # limitations under the License.
 #
 
-version=3.0.4
+version=3.1.0
 groupId=com.nike.cerberus
 artifactId=cms

--- a/src/main/java/ch/qos/logback/core/rolling/AuditLogsS3TimeBasedRollingPolicy.java
+++ b/src/main/java/ch/qos/logback/core/rolling/AuditLogsS3TimeBasedRollingPolicy.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2018 Nike, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.qos.logback.core.rolling;
+
+import com.nike.cerberus.service.ConfigService;
+import com.nike.cerberus.service.S3LogUploaderService;
+
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.stream.Stream;
+
+/**
+ * Rolling policy that will copy audit logs to S3 if enabled when the logs roll.
+ */
+public class AuditLogsS3TimeBasedRollingPolicy<E> extends TimeBasedRollingPolicy<E> {
+
+    private LinkedBlockingQueue<String> logChunkFileS3Queue = new LinkedBlockingQueue<>();
+
+    private S3LogUploaderService s3LogUploaderService = null;
+
+    public void setS3LogUploaderService(S3LogUploaderService s3LogUploaderService) {
+        this.s3LogUploaderService = s3LogUploaderService;
+        if (logChunkFileS3Queue.size() > 0) {
+            Stream.generate(() -> logChunkFileS3Queue.poll()).forEach(s3LogUploaderService::ingestLog);
+        }
+    }
+
+    @Override
+    public void rollover() throws RolloverFailure {
+        super.rollover();
+
+        if (ConfigService.getInstance().isS3AuditLogCopyingEnabled()) {
+            String filename = timeBasedFileNamingAndTriggeringPolicy.getElapsedPeriodsFileName() + ".gz";
+            if (s3LogUploaderService != null) {
+                s3LogUploaderService.ingestLog(filename);
+            } else {
+                logChunkFileS3Queue.offer(filename);
+            }
+        }
+    }
+}

--- a/src/main/java/ch/qos/logback/core/rolling/FiveMinuteRollingFileAppender.java
+++ b/src/main/java/ch/qos/logback/core/rolling/FiveMinuteRollingFileAppender.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2018 Nike, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.qos.logback.core.rolling;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Appender that will roll the logs every 5 minutes
+ */
+public class FiveMinuteRollingFileAppender<E> extends RollingFileAppender<E> {
+    private long start = System.currentTimeMillis();
+
+    @Override
+    public void rollover() {
+        long currentTime = System.currentTimeMillis();
+        long maxIntervalSinceLastLoggingInMillis = TimeUnit.MINUTES.toMillis(1);
+
+        if ((currentTime - start) >= maxIntervalSinceLastLoggingInMillis)
+        {
+            super.rollover();
+            start = System.currentTimeMillis();
+        }
+    }
+}

--- a/src/main/java/com/nike/cerberus/CerberusHttpHeaders.java
+++ b/src/main/java/com/nike/cerberus/CerberusHttpHeaders.java
@@ -9,7 +9,7 @@ public final class CerberusHttpHeaders {
     public static final String HEADER_X_CERBERUS_CLIENT = "X-Cerberus-Client";
     public static final String HEADER_X_REFRESH_TOKEN = "X-Refresh-Token";
     public static final String HEADER_X_FORWARDED_FOR = "X-Forwarded-For";
-    private static final String UNKNOWN = "Unknown";
+    private static final String UNKNOWN = "_unknown";
 
     /**
      * Get the value of the X-Cerberus-Client header or "Unknown" if not found.

--- a/src/main/java/com/nike/cerberus/Main.java
+++ b/src/main/java/com/nike/cerberus/Main.java
@@ -16,6 +16,7 @@
 
 package com.nike.cerberus;
 
+import com.nike.cerberus.service.ConfigService;
 import com.nike.riposte.server.config.ServerConfig;
 import com.nike.riposte.typesafeconfig.TypesafeConfigServer;
 import com.nike.cerberus.server.config.CmsConfig;
@@ -28,6 +29,14 @@ import com.typesafe.config.Config;
  * @author Nic Munroe
  */
 public class Main extends TypesafeConfigServer {
+
+    /**
+     * @return The .conf files merged with the CLI generated properties files
+     */
+    @Override
+    public Config getAppConfig() {
+        return ConfigService.getInstance().getAppConfigMergedWithCliGeneratedProperties();
+    }
 
     @Override
     protected ServerConfig getServerConfig(Config appConfig) {

--- a/src/main/java/com/nike/cerberus/endpoints/AdminStandardEndpoint.java
+++ b/src/main/java/com/nike/cerberus/endpoints/AdminStandardEndpoint.java
@@ -24,8 +24,6 @@ import com.nike.cerberus.service.EventProcessorService;
 import com.nike.riposte.server.http.RequestInfo;
 import com.nike.riposte.server.http.ResponseInfo;
 import io.netty.channel.ChannelHandlerContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.ws.rs.core.SecurityContext;
@@ -39,16 +37,7 @@ import java.util.concurrent.Executor;
  */
 public abstract class AdminStandardEndpoint<I, O> extends AuditableEventEndpoint<I, O> {
 
-    private final Logger log = LoggerFactory.getLogger(getClass());
-
-    protected EventProcessorService eventProcessorService;
-
-    @Inject
-    public void setEventProcessorService(EventProcessorService eventProcessorService) {
-        this.eventProcessorService = eventProcessorService;
-    }
-
-    public final CompletableFuture<ResponseInfo<O>> execute(final RequestInfo<I> request,
+    public final CompletableFuture<ResponseInfo<O>> doExecute(final RequestInfo<I> request,
                                                             final Executor longRunningTaskExecutor,
                                                             final ChannelHandlerContext ctx) {
 
@@ -64,6 +53,7 @@ public abstract class AdminStandardEndpoint<I, O> extends AuditableEventEndpoint
             eventProcessorService.ingestEvent(auditableEvent(cerberusPrincipal, request)
                     .withName(String.format("%s Illegally Invoked", this.getClass().getSimpleName()))
                     .withAction("A non-admin principal attempted to access admin protected endpoint")
+                    .withSuccess(false)
                     .build());
 
             throw new ApiException(DefaultApiError.ACCESS_DENIED);

--- a/src/main/java/com/nike/cerberus/endpoints/CustomizableAuditData.java
+++ b/src/main/java/com/nike/cerberus/endpoints/CustomizableAuditData.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2018 Nike, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nike.cerberus.endpoints;
+
+public class CustomizableAuditData {
+
+    private String description;
+    private String sdbNameSlug;
+
+    public String getDescription() {
+        return description;
+    }
+
+    public CustomizableAuditData setDescription(String description) {
+        this.description = description;
+        return this;
+    }
+
+    public String getSdbNameSlug() {
+        return sdbNameSlug;
+    }
+
+    public CustomizableAuditData setSdbNameSlug(String sdbNameSlug) {
+        this.sdbNameSlug = sdbNameSlug;
+        return this;
+    }
+}

--- a/src/main/java/com/nike/cerberus/endpoints/authentication/RefreshUserToken.java
+++ b/src/main/java/com/nike/cerberus/endpoints/authentication/RefreshUserToken.java
@@ -49,7 +49,7 @@ public class RefreshUserToken extends AuditableEventEndpoint<Void, AuthResponse>
     }
 
     @Override
-    public CompletableFuture<ResponseInfo<AuthResponse>> execute(final RequestInfo<Void> request,
+    public CompletableFuture<ResponseInfo<AuthResponse>> doExecute(final RequestInfo<Void> request,
                                                                  final Executor longRunningTaskExecutor,
                                                                  final ChannelHandlerContext ctx) {
         return CompletableFuture.supplyAsync(

--- a/src/main/java/com/nike/cerberus/endpoints/authentication/RevokeToken.java
+++ b/src/main/java/com/nike/cerberus/endpoints/authentication/RevokeToken.java
@@ -49,7 +49,7 @@ public class RevokeToken extends AuditableEventEndpoint<Void, Void> {
     }
 
     @Override
-    public CompletableFuture<ResponseInfo<Void>> execute(final RequestInfo<Void> request,
+    public CompletableFuture<ResponseInfo<Void>> doExecute(final RequestInfo<Void> request,
                                                          final Executor longRunningTaskExecutor,
                                                          final ChannelHandlerContext ctx) {
         return CompletableFuture.supplyAsync(

--- a/src/main/java/com/nike/cerberus/endpoints/sdb/CreateSafeDepositBoxV1.java
+++ b/src/main/java/com/nike/cerberus/endpoints/sdb/CreateSafeDepositBoxV1.java
@@ -20,10 +20,12 @@ import com.google.common.collect.Maps;
 import com.nike.backstopper.exception.ApiException;
 import com.nike.cerberus.domain.SafeDepositBoxV1;
 import com.nike.cerberus.endpoints.AuditableEventEndpoint;
+import com.nike.cerberus.endpoints.CustomizableAuditData;
 import com.nike.cerberus.error.DefaultApiError;
 import com.nike.cerberus.security.CmsRequestSecurityValidator;
 import com.nike.cerberus.security.CerberusPrincipal;
 import com.nike.cerberus.service.SafeDepositBoxService;
+import com.nike.cerberus.util.Slugger;
 import com.nike.riposte.server.http.RequestInfo;
 import com.nike.riposte.server.http.ResponseInfo;
 import com.nike.riposte.util.AsyncNettyHelper;
@@ -65,7 +67,7 @@ public class CreateSafeDepositBoxV1 extends AuditableEventEndpoint<SafeDepositBo
     }
 
     @Override
-    public CompletableFuture<ResponseInfo<Map<String, String>>> execute(final RequestInfo<SafeDepositBoxV1> request,
+    public CompletableFuture<ResponseInfo<Map<String, String>>> doExecute(final RequestInfo<SafeDepositBoxV1> request,
                                                                         final Executor longRunningTaskExecutor,
                                                                         final ChannelHandlerContext ctx) {
         return CompletableFuture.supplyAsync(
@@ -105,8 +107,10 @@ public class CreateSafeDepositBoxV1 extends AuditableEventEndpoint<SafeDepositBo
     }
 
     @Override
-    protected String describeActionForAuditEvent(RequestInfo<SafeDepositBoxV1> request) {
-        return String.format("Create SDB with name: %s.", request.getContent().getName());
+    protected CustomizableAuditData getCustomizableAuditData(RequestInfo<SafeDepositBoxV1> request) {
+        return new CustomizableAuditData()
+                .setDescription(String.format("Create SDB with name: %s.", request.getContent().getName()))
+                .setSdbNameSlug(Slugger.toSlug(request.getContent().getName()));
     }
 
 }

--- a/src/main/java/com/nike/cerberus/endpoints/sdb/CreateSafeDepositBoxV2.java
+++ b/src/main/java/com/nike/cerberus/endpoints/sdb/CreateSafeDepositBoxV2.java
@@ -20,10 +20,12 @@ package com.nike.cerberus.endpoints.sdb;
 import com.nike.backstopper.exception.ApiException;
 import com.nike.cerberus.domain.SafeDepositBoxV2;
 import com.nike.cerberus.endpoints.AuditableEventEndpoint;
+import com.nike.cerberus.endpoints.CustomizableAuditData;
 import com.nike.cerberus.error.DefaultApiError;
 import com.nike.cerberus.security.CmsRequestSecurityValidator;
 import com.nike.cerberus.security.CerberusPrincipal;
 import com.nike.cerberus.service.SafeDepositBoxService;
+import com.nike.cerberus.util.Slugger;
 import com.nike.riposte.server.http.RequestInfo;
 import com.nike.riposte.server.http.ResponseInfo;
 import com.nike.riposte.util.AsyncNettyHelper;
@@ -62,7 +64,7 @@ public class CreateSafeDepositBoxV2 extends AuditableEventEndpoint<SafeDepositBo
     }
 
     @Override
-    public CompletableFuture<ResponseInfo<SafeDepositBoxV2>> execute(final RequestInfo<SafeDepositBoxV2> request,
+    public CompletableFuture<ResponseInfo<SafeDepositBoxV2>> doExecute(final RequestInfo<SafeDepositBoxV2> request,
                                                                      final Executor longRunningTaskExecutor,
                                                                      final ChannelHandlerContext ctx) {
         return CompletableFuture.supplyAsync(
@@ -99,7 +101,9 @@ public class CreateSafeDepositBoxV2 extends AuditableEventEndpoint<SafeDepositBo
     }
 
     @Override
-    protected String describeActionForAuditEvent(RequestInfo<SafeDepositBoxV2> request) {
-        return String.format("Create SDB with name: %s.", request.getContent().getName());
+    protected CustomizableAuditData getCustomizableAuditData(RequestInfo<SafeDepositBoxV2> request) {
+        return new CustomizableAuditData()
+                .setDescription(String.format("Create SDB with name: %s.", request.getContent().getName()))
+                .setSdbNameSlug(Slugger.toSlug(request.getContent().getName()));
     }
 }

--- a/src/main/java/com/nike/cerberus/endpoints/sdb/GetSafeDepositBoxV1.java
+++ b/src/main/java/com/nike/cerberus/endpoints/sdb/GetSafeDepositBoxV1.java
@@ -19,10 +19,12 @@ package com.nike.cerberus.endpoints.sdb;
 import com.nike.backstopper.exception.ApiException;
 import com.nike.cerberus.domain.SafeDepositBoxV1;
 import com.nike.cerberus.endpoints.AuditableEventEndpoint;
+import com.nike.cerberus.endpoints.CustomizableAuditData;
 import com.nike.cerberus.error.DefaultApiError;
 import com.nike.cerberus.security.CmsRequestSecurityValidator;
 import com.nike.cerberus.security.CerberusPrincipal;
 import com.nike.cerberus.service.SafeDepositBoxService;
+import com.nike.cerberus.util.Slugger;
 import com.nike.riposte.server.http.RequestInfo;
 import com.nike.riposte.server.http.ResponseInfo;
 import com.nike.riposte.util.AsyncNettyHelper;
@@ -55,7 +57,7 @@ public class GetSafeDepositBoxV1 extends AuditableEventEndpoint<Void, SafeDeposi
     }
 
     @Override
-    public CompletableFuture<ResponseInfo<SafeDepositBoxV1>> execute(final RequestInfo<Void> request,
+    public CompletableFuture<ResponseInfo<SafeDepositBoxV1>> doExecute(final RequestInfo<Void> request,
                                                                      final Executor longRunningTaskExecutor,
                                                                      final ChannelHandlerContext ctx) {
         return CompletableFuture.supplyAsync(
@@ -89,10 +91,12 @@ public class GetSafeDepositBoxV1 extends AuditableEventEndpoint<Void, SafeDeposi
     }
 
     @Override
-    protected String describeActionForAuditEvent(RequestInfo<Void> request) {
+    protected CustomizableAuditData getCustomizableAuditData(RequestInfo<Void> request) {
         String sdbId = request.getPathParam("id");
         Optional<String> sdbNameOptional = safeDepositBoxService.getSafeDepositBoxNameById(sdbId);
         String sdbName = sdbNameOptional.orElse(String.format("(Failed to lookup name from id: %s)", sdbId));
-        return String.format("Fetch details for SDB with name: '%s' and id: '%s'", sdbName, sdbId);
+        return  new CustomizableAuditData()
+                .setDescription(String.format("Fetch details for SDB with name: '%s' and id: '%s'", sdbName, sdbId))
+                .setSdbNameSlug(sdbNameOptional.map(Slugger::toSlug).orElse("_unknown_"));
     }
 }

--- a/src/main/java/com/nike/cerberus/endpoints/sdb/GetSafeDepositBoxV2.java
+++ b/src/main/java/com/nike/cerberus/endpoints/sdb/GetSafeDepositBoxV2.java
@@ -20,10 +20,12 @@ package com.nike.cerberus.endpoints.sdb;
 import com.nike.backstopper.exception.ApiException;
 import com.nike.cerberus.domain.SafeDepositBoxV2;
 import com.nike.cerberus.endpoints.AuditableEventEndpoint;
+import com.nike.cerberus.endpoints.CustomizableAuditData;
 import com.nike.cerberus.error.DefaultApiError;
 import com.nike.cerberus.security.CmsRequestSecurityValidator;
 import com.nike.cerberus.security.CerberusPrincipal;
 import com.nike.cerberus.service.SafeDepositBoxService;
+import com.nike.cerberus.util.Slugger;
 import com.nike.riposte.server.http.RequestInfo;
 import com.nike.riposte.server.http.ResponseInfo;
 import com.nike.riposte.util.AsyncNettyHelper;
@@ -55,7 +57,7 @@ public class GetSafeDepositBoxV2 extends AuditableEventEndpoint<Void, SafeDeposi
     }
 
     @Override
-    public CompletableFuture<ResponseInfo<SafeDepositBoxV2>> execute(final RequestInfo<Void> request,
+    public CompletableFuture<ResponseInfo<SafeDepositBoxV2>> doExecute(final RequestInfo<Void> request,
                                                                      final Executor longRunningTaskExecutor,
                                                                      final ChannelHandlerContext ctx) {
         return CompletableFuture.supplyAsync(
@@ -90,10 +92,12 @@ public class GetSafeDepositBoxV2 extends AuditableEventEndpoint<Void, SafeDeposi
     }
 
     @Override
-    protected String describeActionForAuditEvent(RequestInfo<Void> request) {
+    protected CustomizableAuditData getCustomizableAuditData(RequestInfo<Void> request) {
         String sdbId = request.getPathParam("id");
         Optional<String> sdbNameOptional = safeDepositBoxService.getSafeDepositBoxNameById(sdbId);
         String sdbName = sdbNameOptional.orElse(String.format("(Failed to lookup name from id: %s)", sdbId));
-        return String.format("Fetch details for SDB with name: '%s' and id: '%s'", sdbName, sdbId);
+        return  new CustomizableAuditData()
+                .setDescription(String.format("Fetch details for SDB with name: '%s' and id: '%s'", sdbName, sdbId))
+                .setSdbNameSlug(sdbNameOptional.map(Slugger::toSlug).orElse("_unknown_"));
     }
 }

--- a/src/main/java/com/nike/cerberus/endpoints/sdb/GetSafeDepositBoxes.java
+++ b/src/main/java/com/nike/cerberus/endpoints/sdb/GetSafeDepositBoxes.java
@@ -57,7 +57,7 @@ public class GetSafeDepositBoxes extends AuditableEventEndpoint<Void, List<SafeD
     }
 
     @Override
-    public CompletableFuture<ResponseInfo<List<SafeDepositBoxSummary>>> execute(final RequestInfo<Void> request,
+    public CompletableFuture<ResponseInfo<List<SafeDepositBoxSummary>>> doExecute(final RequestInfo<Void> request,
                                                                                 final Executor longRunningTaskExecutor,
                                                                                 final ChannelHandlerContext ctx) {
         return CompletableFuture.supplyAsync(

--- a/src/main/java/com/nike/cerberus/endpoints/sdb/UpdateSafeDepositBoxV2.java
+++ b/src/main/java/com/nike/cerberus/endpoints/sdb/UpdateSafeDepositBoxV2.java
@@ -20,10 +20,12 @@ package com.nike.cerberus.endpoints.sdb;
 import com.nike.backstopper.exception.ApiException;
 import com.nike.cerberus.domain.SafeDepositBoxV2;
 import com.nike.cerberus.endpoints.AuditableEventEndpoint;
+import com.nike.cerberus.endpoints.CustomizableAuditData;
 import com.nike.cerberus.error.DefaultApiError;
 import com.nike.cerberus.security.CmsRequestSecurityValidator;
 import com.nike.cerberus.security.CerberusPrincipal;
 import com.nike.cerberus.service.SafeDepositBoxService;
+import com.nike.cerberus.util.Slugger;
 import com.nike.cerberus.validation.group.Updatable;
 import com.nike.riposte.server.http.RequestInfo;
 import com.nike.riposte.server.http.ResponseInfo;
@@ -59,7 +61,7 @@ public class UpdateSafeDepositBoxV2 extends AuditableEventEndpoint<SafeDepositBo
     }
 
     @Override
-    public CompletableFuture<ResponseInfo<SafeDepositBoxV2>> execute(RequestInfo<SafeDepositBoxV2> request,
+    public CompletableFuture<ResponseInfo<SafeDepositBoxV2>> doExecute(RequestInfo<SafeDepositBoxV2> request,
                                                                      Executor longRunningTaskExecutor,
                                                                      ChannelHandlerContext ctx) {
         return CompletableFuture.supplyAsync(
@@ -100,10 +102,12 @@ public class UpdateSafeDepositBoxV2 extends AuditableEventEndpoint<SafeDepositBo
     }
 
     @Override
-    protected String describeActionForAuditEvent(RequestInfo<SafeDepositBoxV2> request) {
+    protected CustomizableAuditData getCustomizableAuditData(RequestInfo<SafeDepositBoxV2> request) {
         String sdbId = request.getPathParam("id");
         Optional<String> sdbNameOptional = safeDepositBoxService.getSafeDepositBoxNameById(sdbId);
         String sdbName = sdbNameOptional.orElseGet(() -> String.format("(Failed to lookup name from id: %s)", sdbId));
-        return String.format("Update details for SDB with name: '%s' and id: '%s'", sdbName, sdbId);
+        return  new CustomizableAuditData()
+                .setDescription(String.format("Update details for SDB with name: '%s' and id: '%s'", sdbName, sdbId))
+                .setSdbNameSlug(sdbNameOptional.map(Slugger::toSlug).orElse("_unknown_"));
     }
 }

--- a/src/main/java/com/nike/cerberus/endpoints/secret/DeleteSecureData.java
+++ b/src/main/java/com/nike/cerberus/endpoints/secret/DeleteSecureData.java
@@ -53,10 +53,10 @@ public class DeleteSecureData extends SecureDataEndpointV1<Void, Object> {
     }
 
     @Override
-    public CompletableFuture<ResponseInfo<Object>> doExecute(SecureDataRequestInfo requestInfo,
-                                                             RequestInfo<Void> request,
-                                                             Executor longRunningTaskExecutor,
-                                                             ChannelHandlerContext ctx) {
+    public CompletableFuture<ResponseInfo<Object>> executeSecureDataCall(SecureDataRequestInfo requestInfo,
+                                                                         RequestInfo<Void> request,
+                                                                         Executor longRunningTaskExecutor,
+                                                                         ChannelHandlerContext ctx) {
         return CompletableFuture.supplyAsync(
                 AsyncNettyHelper.supplierWithTracingAndMdc(() -> deleteSecureData(requestInfo), ctx),
                 longRunningTaskExecutor

--- a/src/main/java/com/nike/cerberus/endpoints/secret/ReadSecureData.java
+++ b/src/main/java/com/nike/cerberus/endpoints/secret/ReadSecureData.java
@@ -34,8 +34,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import java.io.IOException;
@@ -47,7 +45,6 @@ import java.util.concurrent.Executor;
 
 public class ReadSecureData extends SecureDataEndpointV1<Void, Object> {
 
-    private final Logger log = LoggerFactory.getLogger(getClass());
 
     @Inject
     protected ReadSecureData(SecureDataService secureDataService,
@@ -66,10 +63,10 @@ public class ReadSecureData extends SecureDataEndpointV1<Void, Object> {
     }
 
     @Override
-    public CompletableFuture<ResponseInfo<Object>> doExecute(SecureDataRequestInfo requestInfo,
-                                                             RequestInfo<Void> request,
-                                                             Executor longRunningTaskExecutor,
-                                                             ChannelHandlerContext ctx) {
+    public CompletableFuture<ResponseInfo<Object>> executeSecureDataCall(SecureDataRequestInfo requestInfo,
+                                                                         RequestInfo<Void> request,
+                                                                         Executor longRunningTaskExecutor,
+                                                                         ChannelHandlerContext ctx) {
 
         if (StringUtils.equalsIgnoreCase(request.getQueryParamSingle("list"), "true")) {
             return CompletableFuture.supplyAsync(

--- a/src/main/java/com/nike/cerberus/endpoints/secret/SecureDataEndpointV1.java
+++ b/src/main/java/com/nike/cerberus/endpoints/secret/SecureDataEndpointV1.java
@@ -60,7 +60,7 @@ public abstract class SecureDataEndpointV1<I, O> extends AuditableEventEndpoint<
         this.safeDepositBoxService = safeDepositBoxService;
     }
 
-    public final CompletableFuture<ResponseInfo<O>> execute(RequestInfo<I> request,
+    public final CompletableFuture<ResponseInfo<O>> doExecute(RequestInfo<I> request,
                                                             Executor longRunningTaskExecutor,
                                                             ChannelHandlerContext ctx) {
 
@@ -114,7 +114,7 @@ public abstract class SecureDataEndpointV1<I, O> extends AuditableEventEndpoint<
 
         requestInfo.setSdbid(sdbId.get());
 
-        return doExecute(requestInfo, request, longRunningTaskExecutor, ctx);
+        return executeSecureDataCall(requestInfo, request, longRunningTaskExecutor, ctx);
     }
 
     private boolean doesRequestHaveRequiredParams(String category, String sdbSlug) {
@@ -196,11 +196,16 @@ public abstract class SecureDataEndpointV1<I, O> extends AuditableEventEndpoint<
 
     }
 
+    @Override
+    protected String getSlugifiedSdbName(RequestInfo<I> request) {
+        return parseInfoFromPath(request.getPath()).getSdbSlug();
+    }
+
     protected abstract ResponseInfo<O> generateVaultStyleResponse(VaultStyleErrorResponse response, int statusCode);
 
-    protected abstract CompletableFuture<ResponseInfo<O>> doExecute(SecureDataRequestInfo requestInfo,
-                                                                    RequestInfo<I> request,
-                                                                    Executor longRunningTaskExecutor,
-                                                                    ChannelHandlerContext ctx);
+    protected abstract CompletableFuture<ResponseInfo<O>> executeSecureDataCall(SecureDataRequestInfo requestInfo,
+                                                                                RequestInfo<I> request,
+                                                                                Executor longRunningTaskExecutor,
+                                                                                ChannelHandlerContext ctx);
 
 }

--- a/src/main/java/com/nike/cerberus/endpoints/secret/WriteSecureData.java
+++ b/src/main/java/com/nike/cerberus/endpoints/secret/WriteSecureData.java
@@ -57,10 +57,10 @@ public class WriteSecureData extends SecureDataEndpointV1<Object, Object> {
     }
 
     @Override
-    public CompletableFuture<ResponseInfo<Object>> doExecute(SecureDataRequestInfo requestInfo,
-                                                             RequestInfo<Object> request,
-                                                             Executor longRunningTaskExecutor,
-                                                             ChannelHandlerContext ctx) {
+    public CompletableFuture<ResponseInfo<Object>> executeSecureDataCall(SecureDataRequestInfo requestInfo,
+                                                                         RequestInfo<Object> request,
+                                                                         Executor longRunningTaskExecutor,
+                                                                         ChannelHandlerContext ctx) {
 
         return CompletableFuture.supplyAsync(
                 AsyncNettyHelper.supplierWithTracingAndMdc(() -> writeSecureData(requestInfo, request), ctx),

--- a/src/main/java/com/nike/cerberus/event/processor/AuditLogProcessor.java
+++ b/src/main/java/com/nike/cerberus/event/processor/AuditLogProcessor.java
@@ -51,29 +51,29 @@ public class AuditLogProcessor implements EventProcessor {
             Optional<CerberusPrincipal> cerberusPrincipal = event.getPrincipalAsCerberusPrincipal();
 
             ImmutableMap<String, String> flattenedAuditEvent = ImmutableMap.<String, String>builder()
-                    .put("event-timestamp", event.getTimestamp().format(ATHENA_DATE_FORMATTER))
-                    .put("principal-name", event.getPrincipalName())
-                    .put("principal-type", cerberusPrincipal
+                    .put("event_timestamp", event.getTimestamp().format(ATHENA_DATE_FORMATTER))
+                    .put("principal_name", event.getPrincipalName())
+                    .put("principal_type", cerberusPrincipal
                             .map(p -> cerberusPrincipal.get().getPrincipalType().getName()).orElse(AuditableEvent.UNKNOWN))
-                    .put("principal-token-created", cerberusPrincipal
+                    .put("principal_token_created", cerberusPrincipal
                             .map(p -> cerberusPrincipal.get().getTokenCreated().format(ATHENA_DATE_FORMATTER))
                             .orElseGet(() -> OffsetDateTime.parse(PARTY_LIKE_ITS_99, ISO_OFFSET_DATE_TIME).format(ATHENA_DATE_FORMATTER)))
-                    .put("principal-token-expires", cerberusPrincipal
+                    .put("principal_token_expires", cerberusPrincipal
                             .map(p -> cerberusPrincipal.get().getTokenExpires().format(ATHENA_DATE_FORMATTER))
                             .orElseGet(() -> OffsetDateTime.parse(PARTY_LIKE_ITS_99, ISO_OFFSET_DATE_TIME).format(ATHENA_DATE_FORMATTER)))
-                    .put("principal-is-admin", cerberusPrincipal
+                    .put("principal_is_admin", cerberusPrincipal
                             .map(p -> String.valueOf(p.isAdmin())).orElseGet(() -> String.valueOf(false)))
-                    .put("ip-address", event.getIpAddress())
-                    .put("x-forwarded-for", event.getxForwardedFor())
-                    .put("client-version", event.getClientVersion())
-                    .put("http-method", event.getMethodAsString())
+                    .put("ip_address", event.getIpAddress())
+                    .put("x_forwarded_for", event.getxForwardedFor())
+                    .put("client_version", event.getClientVersion())
+                    .put("http_method", event.getMethodAsString())
                     .put("path", event.getPath())
                     .put("action", event.getAction())
-                    .put("was-success", String.valueOf(event.isSuccess()))
+                    .put("was_success", String.valueOf(event.isSuccess()))
                     .put("name", event.getName())
-                    .put("sdb-name-slug", event.getSdbNameSlug())
-                    .put("originating-class", event.getOriginatingClass())
-                    .put("trace-id", event.getTraceId())
+                    .put("sdb_name_slug", event.getSdbNameSlug())
+                    .put("originating_class", event.getOriginatingClass())
+                    .put("trace_id", event.getTraceId())
                     .build();
 
             try {

--- a/src/main/java/com/nike/cerberus/event/processor/AuditLogProcessor.java
+++ b/src/main/java/com/nike/cerberus/event/processor/AuditLogProcessor.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2018 Nike, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nike.cerberus.event.processor;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import com.nike.cerberus.event.AuditableEvent;
+import com.nike.cerberus.event.Event;
+import com.nike.cerberus.security.CerberusPrincipal;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+
+import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+
+/**
+ * Event Processor that only cares about auditable events and outputs to a special audit log appender in a flat json
+ * format that is optimized for use with AWS Athena
+ */
+public class AuditLogProcessor implements EventProcessor {
+
+    protected final Logger auditLogger = LoggerFactory.getLogger(this.getClass());
+
+    private static final DateTimeFormatter ATHENA_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd hh:mm:ss");
+    private static final String PARTY_LIKE_ITS_99 = "1999-01-01T01:00:00+00:00";
+
+    private final ObjectMapper om = new ObjectMapper();
+
+    @Override
+    public void process(Event originalEvent) {
+        getAuditableEvent(originalEvent).ifPresent(event -> {
+
+            Optional<CerberusPrincipal> cerberusPrincipal = event.getPrincipalAsCerberusPrincipal();
+
+            ImmutableMap<String, String> flattenedAuditEvent = ImmutableMap.<String, String>builder()
+                    .put("event-timestamp", event.getTimestamp().format(ATHENA_DATE_FORMATTER))
+                    .put("principal-name", event.getPrincipalName())
+                    .put("principal-type", cerberusPrincipal
+                            .map(p -> cerberusPrincipal.get().getPrincipalType().getName()).orElse(AuditableEvent.UNKNOWN))
+                    .put("principal-token-created", cerberusPrincipal
+                            .map(p -> cerberusPrincipal.get().getTokenCreated().format(ATHENA_DATE_FORMATTER))
+                            .orElseGet(() -> OffsetDateTime.parse(PARTY_LIKE_ITS_99, ISO_OFFSET_DATE_TIME).format(ATHENA_DATE_FORMATTER)))
+                    .put("principal-token-expires", cerberusPrincipal
+                            .map(p -> cerberusPrincipal.get().getTokenExpires().format(ATHENA_DATE_FORMATTER))
+                            .orElseGet(() -> OffsetDateTime.parse(PARTY_LIKE_ITS_99, ISO_OFFSET_DATE_TIME).format(ATHENA_DATE_FORMATTER)))
+                    .put("principal-is-admin", cerberusPrincipal
+                            .map(p -> String.valueOf(p.isAdmin())).orElseGet(() -> String.valueOf(false)))
+                    .put("ip-address", event.getIpAddress())
+                    .put("x-forwarded-for", event.getxForwardedFor())
+                    .put("client-version", event.getClientVersion())
+                    .put("http-method", event.getMethodAsString())
+                    .put("path", event.getPath())
+                    .put("action", event.getAction())
+                    .put("was-success", String.valueOf(event.isSuccess()))
+                    .put("name", event.getName())
+                    .put("sdb-name-slug", event.getSdbNameSlug())
+                    .put("originating-class", event.getOriginatingClass())
+                    .put("trace-id", event.getTraceId())
+                    .build();
+
+            try {
+                auditLogger.info(om.writeValueAsString(flattenedAuditEvent));
+            } catch (JsonProcessingException e) {
+                LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME).error("failed to log audit event", e);
+            }
+        });
+    }
+
+    private Optional<AuditableEvent> getAuditableEvent(Event event) {
+        return event instanceof AuditableEvent ? Optional.of((AuditableEvent) event) : Optional.empty();
+    }
+
+    @Override
+    public String getName() {
+        return "audit-log-processor";
+    }
+
+}

--- a/src/main/java/com/nike/cerberus/security/CerberusPrincipal.java
+++ b/src/main/java/com/nike/cerberus/security/CerberusPrincipal.java
@@ -21,6 +21,7 @@ import com.nike.cerberus.PrincipalType;
 import com.nike.cerberus.domain.CerberusAuthToken;
 
 import java.security.Principal;
+import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -103,6 +104,18 @@ public class CerberusPrincipal implements Principal {
 
     public Integer getTokenRefreshCount() {
         return cerberusAuthToken.getRefreshCount();
+    }
+
+    public OffsetDateTime getTokenCreated() {
+        return cerberusAuthToken.getCreated();
+    }
+
+    public OffsetDateTime getTokenExpires() {
+        return cerberusAuthToken.getExpires();
+    }
+
+    public boolean isAdmin() {
+        return cerberusAuthToken.isAdmin();
     }
 
     @Override

--- a/src/main/java/com/nike/cerberus/security/CmsRequestSecurityValidator.java
+++ b/src/main/java/com/nike/cerberus/security/CmsRequestSecurityValidator.java
@@ -50,17 +50,14 @@ public class CmsRequestSecurityValidator implements RequestSecurityValidator {
 
     private final Collection<Endpoint<?>> endpointsToValidate;
     private final AuthTokenService authTokenService;
-    private final EventProcessorService eventProcessorService;
 
     public CmsRequestSecurityValidator(Collection<Endpoint<?>> endpointsToValidate,
-                                       AuthTokenService authTokenService,
-                                       EventProcessorService eventProcessorService) {
+                                       AuthTokenService authTokenService) {
 
         this.endpointsToValidate = endpointsToValidate;
         this.endpointsToValidate.forEach(endpoint -> log.info("auth protected: {}", endpoint.getClass().getName()));
 
         this.authTokenService = authTokenService;
-        this.eventProcessorService = eventProcessorService;
     }
 
     @Override
@@ -81,20 +78,6 @@ public class CmsRequestSecurityValidator implements RequestSecurityValidator {
             final CerberusSecurityContext securityContext = new CerberusSecurityContext(principal,
                     URI.create(requestInfo.getUri()).getScheme());
             requestInfo.addRequestAttribute(SECURITY_CONTEXT_ATTR_KEY, securityContext);
-        }
-
-        processPrincipalEvent(principal, requestInfo, endpoint);
-    }
-
-    private void processPrincipalEvent(CerberusPrincipal principal,
-                                       RequestInfo<?> requestInfo,
-                                       Endpoint<?> endpoint) {
-
-        if (endpoint instanceof AuditableEventEndpoint) {
-            //noinspection unchecked
-            eventProcessorService.ingestEvent(
-                    ((AuditableEventEndpoint) endpoint).generateAuditableEvent(principal, requestInfo)
-            );
         }
     }
 

--- a/src/main/java/com/nike/cerberus/server/config/guice/GuiceProvidedServerConfigValues.java
+++ b/src/main/java/com/nike/cerberus/server/config/guice/GuiceProvidedServerConfigValues.java
@@ -27,6 +27,7 @@ import com.nike.riposte.server.config.impl.DependencyInjectionProvidedServerConf
 import com.nike.riposte.server.error.handler.RiposteErrorHandler;
 import com.nike.riposte.server.error.handler.RiposteUnhandledErrorHandler;
 import com.nike.riposte.server.error.validation.RequestValidator;
+import com.nike.riposte.server.hooks.ServerShutdownHook;
 import com.nike.riposte.server.http.Endpoint;
 import io.netty.handler.ssl.SslContext;
 import com.nike.riposte.server.http.filter.RequestAndResponseFilter;
@@ -55,6 +56,7 @@ public class GuiceProvidedServerConfigValues extends DependencyInjectionProvided
     public final CmsRequestSecurityValidator cmsRequestSecurityValidator;
     public final List<RequestAndResponseFilter> requestAndResponseFilters;
     public final SslContext sslContext;
+    public final List<ServerShutdownHook> shutdownHooks;
 
     @Inject
     public GuiceProvidedServerConfigValues(@Named("endpoints.port") Integer endpointsPort,
@@ -74,8 +76,8 @@ public class GuiceProvidedServerConfigValues extends DependencyInjectionProvided
                                            CmsRequestSecurityValidator cmsRequestSecurityValidator,
                                            StrictTransportSecurityRequestAndResponseFilter strictTransportSecurityRequestAndResponseFilter,
                                            HystrixRequestAndResponseFilter hystrixRequestAndResponseFilter,
-                                           SslContext sslContext
-    ) {
+                                           SslContext sslContext,
+                                           @Named("shutdownHooks") List<ServerShutdownHook> shutdownHooks) {
         super(endpointsPort, endpointsSslPort, endpointsUseSsl, numBossThreads, numWorkerThreads, maxRequestSizeInBytes, appEndpoints,
               debugActionsEnabled, debugChannelLifecycleLoggingEnabled);
 
@@ -85,6 +87,7 @@ public class GuiceProvidedServerConfigValues extends DependencyInjectionProvided
         this.metricsListener = metricsListener;
         this.appInfoFuture = appInfoFuture;
         this.cmsRequestSecurityValidator = cmsRequestSecurityValidator;
+        this.shutdownHooks = shutdownHooks;
         this.requestAndResponseFilters = Lists.newArrayList(hystrixRequestAndResponseFilter, strictTransportSecurityRequestAndResponseFilter);
         this.sslContext = sslContext;
     }

--- a/src/main/java/com/nike/cerberus/service/ConfigService.java
+++ b/src/main/java/com/nike/cerberus/service/ConfigService.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2018 Nike, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nike.cerberus.service;
+
+import com.amazonaws.encryptionsdk.AwsCrypto;
+import com.nike.cerberus.config.CmsEnvPropertiesLoader;
+import com.nike.internal.util.Pair;
+import com.nike.riposte.typesafeconfig.util.TypesafeConfigUtil;
+import com.nike.riposte.util.MainClassUtils;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Configuration Service for retrieving the TypeSafe Config merged with S3 cli generated properties
+ */
+public class ConfigService {
+
+    private static ConfigService instance = null;
+
+    private static final String REGION_KEY = "EC2_REGION";
+    private static final String BUCKET_NAME_KEY = "CONFIG_S3_BUCKET";
+    private static final String CMS_DISABLE_ENV_LOAD_FLAG = "cms.env.load.disable";
+    private static final String AUDIT_LOGGING_ENABLED_KEY = "cms.event.processors.com.nike.cerberus.event.processor.AuditLogProcessor";
+    private static final String AUDIT_BUCKET_CONFIG_KEY = "cms.audit.bucket";
+    private static final String AUDIT_BUCKET_REGION_CONFIG_KEY = "cms.audit.bucket_region";
+
+    private final Config mergedConfig;
+    private CmsEnvPropertiesLoader cmsEnvPropertiesLoader;
+    private final boolean s3ConfigEnabled;
+
+    private ConfigService() {
+        Pair<String, String> appIdAndEnvironmentPair = MainClassUtils.getAppIdAndEnvironmentFromSystemProperties();
+        Config appConfig = TypesafeConfigUtil
+                .loadConfigForAppIdAndEnvironment(appIdAndEnvironmentPair.getLeft(), appIdAndEnvironmentPair.getRight());
+
+        Properties cliGeneratedProperties;
+        if (s3ConfigEnabled =
+                appConfig.hasPath(CMS_DISABLE_ENV_LOAD_FLAG) && appConfig.getBoolean(CMS_DISABLE_ENV_LOAD_FLAG)) {
+            cliGeneratedProperties = new Properties();
+        } else {
+            cmsEnvPropertiesLoader = new CmsEnvPropertiesLoader(
+                    System.getenv(BUCKET_NAME_KEY),
+                    System.getenv(REGION_KEY),
+                    new AwsCrypto());
+            cliGeneratedProperties = cmsEnvPropertiesLoader.getProperties();
+        }
+        mergedConfig = ConfigFactory.parseProperties(cliGeneratedProperties).withFallback(appConfig);
+    }
+
+    public static ConfigService getInstance() {
+        if (instance == null) {
+            instance = new ConfigService();
+        }
+        return instance;
+    }
+
+    /**
+     * Returns whether or not config can be loaded from S3
+     */
+    public boolean isS3ConfigDisabled() {
+        return s3ConfigEnabled;
+    }
+
+    /**
+     * @return Typesafe app config merged into CLI generated properties
+     */
+    public Config getAppConfigMergedWithCliGeneratedProperties() {
+        return mergedConfig;
+    }
+
+    /**
+     * Get the value of the Certificate from S3
+     * @param certificateName
+     */
+    public String getCertificate(String certificateName) {
+        return cmsEnvPropertiesLoader.getCertificate(certificateName);
+    }
+
+    /**
+     * Get the value of the PKCS8 Private Key from S3.
+     *
+     * The SslContextBuilder and Netty´s SslContext implementations only support PKCS8 keys.
+     *
+     * http://netty.io/wiki/sslcontextbuilder-and-private-key.html
+     * @param certificateName
+     */
+    public String getPrivateKey(String certificateName) {
+        return cmsEnvPropertiesLoader.getPrivateKey(certificateName);
+    }
+
+    /**
+     * @return Whether or not the appropriate settings have been set to the enable audit logging appender and audit logging event processor.
+     */
+    public boolean isAuditLoggingEnabled() {
+        return mergedConfig.hasPath(AUDIT_LOGGING_ENABLED_KEY) && mergedConfig.getBoolean(AUDIT_LOGGING_ENABLED_KEY);
+    }
+
+    /**
+     * @return Whether or not the appropriate setting have been set to upload the audit log files as they get rolled by the appender
+     */
+    public boolean isS3AuditLogCopyingEnabled() {
+        String bucket = mergedConfig.hasPath(AUDIT_BUCKET_CONFIG_KEY) ? mergedConfig.getString(AUDIT_BUCKET_CONFIG_KEY) : "";
+        String bucketRegion = mergedConfig.hasPath(AUDIT_BUCKET_REGION_CONFIG_KEY) ? mergedConfig.getString(AUDIT_BUCKET_REGION_CONFIG_KEY) : "";
+        return StringUtils.isNotBlank(bucket) && StringUtils.isNotBlank(bucketRegion);
+    }
+
+    /**
+     * Looks through the merged config to get the set of class names of the event processors to create
+     */
+    public Set<String> getEnabledEventProcessors() {
+        if (mergedConfig.hasPath("cms.event.processors")) {
+            return mergedConfig.getConfig("cms.event.processors").entrySet().stream()
+                    .map(e -> org.apache.commons.lang.StringUtils.removeStart(e.getKey(), "\"cms.event.processors\""))
+                    .collect(Collectors.toSet());
+        }
+        return new HashSet<>();
+    }
+}

--- a/src/main/java/com/nike/cerberus/service/EncryptionService.java
+++ b/src/main/java/com/nike/cerberus/service/EncryptionService.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.inject.Singleton;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.HashMap;
@@ -27,6 +28,7 @@ import java.util.stream.Collectors;
 /**
  * Service for performing encryption and decryption of secrets using the 'AWS Encryption SDK'.
  */
+@Singleton
 public class EncryptionService {
 
     /**

--- a/src/main/java/com/nike/cerberus/service/S3LogUploaderService.java
+++ b/src/main/java/com/nike/cerberus/service/S3LogUploaderService.java
@@ -92,11 +92,10 @@ public class S3LogUploaderService implements ServerShutdownHook {
         Pattern dtPattern = Pattern.compile(".*?(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2})_(?<hour>\\d{2}).*");
         Matcher matcher = dtPattern.matcher(fileName);
         if(matcher.find()) {
-            return String.format("partitioned/%s/%s/%s/%s",
+            return String.format("partitioned/%s/%s/%s",
                     matcher.group("year"),
                     matcher.group("month"),
-                    matcher.group("day"),
-                    matcher.group("hour"));
+                    matcher.group("day"));
         } else {
             return "un-partitioned";
         }

--- a/src/main/java/com/nike/cerberus/service/S3LogUploaderService.java
+++ b/src/main/java/com/nike/cerberus/service/S3LogUploaderService.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2018 Nike, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nike.cerberus.service;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.rolling.AuditLogsS3TimeBasedRollingPolicy;
+import ch.qos.logback.core.rolling.FiveMinuteRollingFileAppender;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.nike.riposte.server.config.ServerConfig;
+import com.nike.riposte.server.hooks.ServerShutdownHook;
+import io.netty.channel.Channel;
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.io.File;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Service that is intended to be created eagerly by Guice and inject itself into the LogBack rolling policy so that
+ * it can ingest filenames that the roller creates when it rolls audit logs and upload them to S3
+ *
+ * Because the Appenders and other Logback stuff are created before Guice, we get the policy from the LoggerFactory
+ * and inject this into it manually using the setter method.
+ */
+@Singleton
+public class S3LogUploaderService implements ServerShutdownHook {
+
+    private final Logger log = LoggerFactory.getLogger(this.getClass());
+
+    private static final String AUDIT_LOG_LOG_NAME = "com.nike.cerberus.event.processor.AuditLogProcessor";
+    private static final String AUDIT_LOG_APPENDER = "audit-log-appender";
+
+    private final ExecutorService executor = Executors.newSingleThreadExecutor();
+    private final AmazonS3 amazonS3;
+    private final String bucket;
+    private final ConfigService configService;
+
+    @Inject
+    public S3LogUploaderService(@Named("cms.audit.bucket") String bucket,
+                                @Named("cms.audit.bucket_region") String bucketRegion,
+                                ConfigService configService) {
+        this.bucket = bucket;
+        amazonS3 = AmazonS3Client.builder().withRegion(bucketRegion).build();
+        this.configService = configService;
+
+        // Inject this into the logback rolling policy which was created before guice land exists
+        getRollingPolicy().ifPresent(policy -> {
+            log.info("S3 Rolling Policy detected injecting S3 Log Uploader Service");
+            policy.setS3LogUploaderService(this);
+        });
+    }
+
+    /**
+     * Convenience method for sleeping
+     */
+    private void sleep(int time, TimeUnit timeUnit) {
+        try {
+            Thread.sleep(timeUnit.toMillis(time));
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    /**
+     * Gets the folder structure to use in S3 to enable dt partitioning
+     */
+    protected String getPartition(String fileName) {
+        Pattern dtPattern = Pattern.compile(".*?(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2})_(?<hour>\\d{2}).*");
+        Matcher matcher = dtPattern.matcher(fileName);
+        if(matcher.find()) {
+            return String.format("partitioned/%s/%s/%s/%s",
+                    matcher.group("year"),
+                    matcher.group("month"),
+                    matcher.group("day"),
+                    matcher.group("hour"));
+        } else {
+            return "un-partitioned";
+        }
+    }
+
+    /**
+     * Asynchronously ingests logfiles and uploads them to S3
+     *
+     * @param filename The log file that has been rolled and is ready to be uploaded to S3
+     */
+    public void ingestLog(String filename) {
+        executor.execute(() -> processLogFile(filename, 0));
+    }
+
+    /**
+     * Uploads a file to S3
+     * @param filename The file to upload to s3
+     * @param retryCount The retry count
+     */
+    private void processLogFile(String filename, int retryCount) {
+        log.info("process log file called with filename: {}, retry count: {}", filename, retryCount);
+        final File rolledLogFile = new File(filename);
+        // poll for 30 seconds waiting for file to exist or bail
+        int i = 0;
+        do {
+            sleep(1, TimeUnit.SECONDS);
+            log.info("Does '{}' exist: {}, length: {}, can read: {}, poll count: {}",
+                    filename, rolledLogFile.exists(), rolledLogFile.length(), rolledLogFile.canRead(), i);
+            i++;
+        } while (!rolledLogFile.exists() || i >= 30);
+
+        // if file does not exist or empty, do nothing
+        if (!rolledLogFile.exists() || rolledLogFile.length() == 0) {
+            log.error("File '{}' does not exist or is empty returning", filename);
+            return;
+        }
+
+        String partition = getPartition(rolledLogFile.getName());
+        String key = String.format("audit-logs/%s/%s", partition, rolledLogFile.getName());
+
+        try {
+            log.info("Copying log chunk to s3://{}/{}", bucket, key);
+            amazonS3.putObject(bucket, key, rolledLogFile);
+            FileUtils.deleteQuietly(rolledLogFile);
+            log.info("File: '{}' successfully copied and deleted.", rolledLogFile.getName());
+        } catch (Exception e) {
+            log.error("Failed to copy log chunk to s3 Bucket: {} key: {} files: {}",
+                    bucket, key, rolledLogFile.getName(), e);
+            if (retryCount < 10) {
+                sleep(1, TimeUnit.SECONDS);
+                processLogFile(filename, retryCount + 1);
+            }
+            throw e;
+        }
+    }
+
+    /**
+     * Riposte shutdown hook, for ensuring the the remaining log data gets shipped to s3 on shutdown
+     */
+    @Override
+    public void executeServerShutdownHook(ServerConfig serverConfig, Channel channel) {
+        log.info("Riposte shutdown event detected, telling appender to roll current log");
+        getRollingPolicy().ifPresent(AuditLogsS3TimeBasedRollingPolicy::rollover);
+        log.info("Letting thread pool finish uploading remaining queued logs, with 10 minute timeout");
+        executor.shutdown();
+        log.info("Finished processing log upload queue");
+        try {
+            executor.awaitTermination(10, TimeUnit.MINUTES);
+        } catch (InterruptedException e) {
+            log.error("Failed to wait and allow executor to finish jobs, shutting down now");
+            executor.shutdownNow();
+        }
+    }
+
+    /**
+     * @return the AuditLogsS3FixedWindowRollingPolicy from the audit logger that implements ServerShutdownHook
+     * so that it can be registered with the shutdown hooks
+     */
+    private Optional<AuditLogsS3TimeBasedRollingPolicy> getRollingPolicy() {
+        if (configService.isAuditLoggingEnabled()) {
+            ch.qos.logback.classic.Logger auditLogger = (ch.qos.logback.classic.Logger)
+                    LoggerFactory.getLogger(AUDIT_LOG_LOG_NAME);
+
+            FiveMinuteRollingFileAppender<ILoggingEvent> appender = (FiveMinuteRollingFileAppender<ILoggingEvent>)
+                    auditLogger.getAppender(AUDIT_LOG_APPENDER);
+
+            return Optional.ofNullable((AuditLogsS3TimeBasedRollingPolicy) appender.getRollingPolicy());
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/com/nike/cerberus/service/S3LogUploaderService.java
+++ b/src/main/java/com/nike/cerberus/service/S3LogUploaderService.java
@@ -86,16 +86,17 @@ public class S3LogUploaderService implements ServerShutdownHook {
     }
 
     /**
-     * Gets the folder structure to use in S3 to enable dt partitioning
+     * Gets the folder structure to use in S3 to enable dt dynamic partitioning
      */
     protected String getPartition(String fileName) {
         Pattern dtPattern = Pattern.compile(".*?(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2})_(?<hour>\\d{2}).*");
         Matcher matcher = dtPattern.matcher(fileName);
         if(matcher.find()) {
-            return String.format("partitioned/%s/%s/%s",
+            return String.format("partitioned/year=%s/month=%s/day=%s/hour=%s",
                     matcher.group("year"),
                     matcher.group("month"),
-                    matcher.group("day"));
+                    matcher.group("day"),
+                    matcher.group("hour"));
         } else {
             return "un-partitioned";
         }

--- a/src/main/java/com/nike/cerberus/util/Slugger.java
+++ b/src/main/java/com/nike/cerberus/util/Slugger.java
@@ -31,7 +31,7 @@ public class Slugger {
 
     public static final Pattern WHITESPACE = Pattern.compile("[\\s]");
 
-    public String toSlug(String input) {
+    public static String toSlug(String input) {
         final String nowhitespace = WHITESPACE.matcher(input).replaceAll("-");
         final String normalized = Normalizer.normalize(nowhitespace, Normalizer.Form.NFD);
         final String slug = NONLATIN.matcher(normalized).replaceAll("");

--- a/src/main/resources/cms.conf
+++ b/src/main/resources/cms.conf
@@ -143,9 +143,7 @@ cms.jobs.configuredJobs=[
 # See https://github.com/Nike-Inc/cerberus-util-scripts/blob/master/bash_scripts/start-jar-script.sh#L72
 # ex set JVM_BEHAVIOR_ARGS='-cp /opt/cerberus/*.jar' with your jar there.
 # You can disable event logging locally or for your specific env by removing the default LoggingEventProcessor
-cms.event.enabledProcessors=[
-    "com.nike.cerberus.event.processor.LoggingEventProcessor"
-]
+cms.event.processors.com.nike.cerberus.event.processor.LoggingEventProcessor=true
 
 # ExpiredTokenCleanUpJob config
 cms.jobs.ExpiredTokenCleanUpJob.maxNumberOfTokensToDeletePerJobRun=2500

--- a/src/test/java/com/nike/cerberus/CerberusHttpHeadersTest.java
+++ b/src/test/java/com/nike/cerberus/CerberusHttpHeadersTest.java
@@ -26,7 +26,7 @@ public class CerberusHttpHeadersTest {
     public void test_getClientVersion_when_null() {
         RequestInfo request = mock(RequestInfo.class);
 
-        Assert.assertEquals("Unknown", CerberusHttpHeaders.getClientVersion(request));
+        Assert.assertEquals("_unknown", CerberusHttpHeaders.getClientVersion(request));
     }
 
     @Test
@@ -55,6 +55,6 @@ public class CerberusHttpHeadersTest {
     public void test_getXForwardedClientIp_with_null() {
         RequestInfo request = mock(RequestInfo.class);
 
-        Assert.assertEquals("Unknown", CerberusHttpHeaders.getXForwardedClientIp(request));
+        Assert.assertEquals("_unknown", CerberusHttpHeaders.getXForwardedClientIp(request));
     }
 }

--- a/src/test/java/com/nike/cerberus/endpoints/AdminStandardEndpointTest.java
+++ b/src/test/java/com/nike/cerberus/endpoints/AdminStandardEndpointTest.java
@@ -30,6 +30,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
 import javax.ws.rs.core.SecurityContext;
@@ -50,14 +51,12 @@ public class AdminStandardEndpointTest {
     @Mock
     private EventProcessorService eventProcessorService;
 
-    private AdminStandardEndpoint<Void, Void> subject;
+    @InjectMocks
+    private AdminStandardEndpoint<Void, Void> subject = new AdminStandardEndpointImpl();
 
     @Before
     public void before() throws Exception {
         initMocks(this);
-
-        subject = new AdminStandardEndpointImpl();
-        subject.setEventProcessorService(eventProcessorService);
     }
 
     @Test

--- a/src/test/java/com/nike/cerberus/endpoints/secret/SecureDataEndpointV1Test.java
+++ b/src/test/java/com/nike/cerberus/endpoints/secret/SecureDataEndpointV1Test.java
@@ -78,7 +78,7 @@ public class SecureDataEndpointV1Test {
         }
 
         @Override
-        protected CompletableFuture<ResponseInfo<Void>> doExecute(SecureDataRequestInfo requestInfo, RequestInfo<Void> request, Executor longRunningTaskExecutor, ChannelHandlerContext ctx) {
+        protected CompletableFuture<ResponseInfo<Void>> executeSecureDataCall(SecureDataRequestInfo requestInfo, RequestInfo<Void> request, Executor longRunningTaskExecutor, ChannelHandlerContext ctx) {
             return null;
         }
 

--- a/src/test/java/com/nike/cerberus/security/CmsRequestSecurityValidatorTest.java
+++ b/src/test/java/com/nike/cerberus/security/CmsRequestSecurityValidatorTest.java
@@ -55,16 +55,13 @@ public class CmsRequestSecurityValidatorTest {
     @Mock
     private AuthTokenService authTokenService;
 
-    @Mock
-    private EventProcessorService eventProcessorService;
-
     private CmsRequestSecurityValidator subject;
 
     @Before
     public void setUp() throws Exception {
         initMocks(this);
 
-        subject = new CmsRequestSecurityValidator(securedEndpoints, authTokenService, eventProcessorService);
+        subject = new CmsRequestSecurityValidator(securedEndpoints, authTokenService);
     }
 
     @Test

--- a/src/test/java/com/nike/cerberus/service/S3LogUploaderServiceTest.java
+++ b/src/test/java/com/nike/cerberus/service/S3LogUploaderServiceTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2018 Nike, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nike.cerberus.service;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class S3LogUploaderServiceTest {
+
+    @Mock
+    private ConfigService configService;
+
+    private S3LogUploaderService s3LogUploader;
+
+    @Before
+    public void before() {
+        initMocks(this);
+        s3LogUploader = new S3LogUploaderService("fake-bucket", "us-west-2", configService);
+    }
+
+    @Test
+    public void test_that_getPartition_works() {
+        String fileName = "localhost-audit.2018-01-29_12-58.log.gz";
+        String actual = s3LogUploader.getPartition(fileName);
+        String expected = "partitioned/2018/01/29/12";
+        assertEquals(expected, actual);
+    }
+
+}

--- a/src/test/java/com/nike/cerberus/service/S3LogUploaderServiceTest.java
+++ b/src/test/java/com/nike/cerberus/service/S3LogUploaderServiceTest.java
@@ -40,7 +40,7 @@ public class S3LogUploaderServiceTest {
     public void test_that_getPartition_works() {
         String fileName = "localhost-audit.2018-01-29_12-58.log.gz";
         String actual = s3LogUploader.getPartition(fileName);
-        String expected = "partitioned/2018/01/29/12";
+        String expected = "partitioned/2018/01/29";
         assertEquals(expected, actual);
     }
 

--- a/src/test/java/com/nike/cerberus/service/S3LogUploaderServiceTest.java
+++ b/src/test/java/com/nike/cerberus/service/S3LogUploaderServiceTest.java
@@ -40,7 +40,7 @@ public class S3LogUploaderServiceTest {
     public void test_that_getPartition_works() {
         String fileName = "localhost-audit.2018-01-29_12-58.log.gz";
         String actual = s3LogUploader.getPartition(fileName);
-        String expected = "partitioned/2018/01/29";
+        String expected = "partitioned/year=2018/month=01/day=29/hour=12";
         assertEquals(expected, actual);
     }
 


### PR DESCRIPTION
- Creates an optional audit log that is disabled by default that will log messages in a flattened JSON object that is Athena friendly.
- If the properties are set in environment.properties the logback configuration will automatically copy the audit logs that get rolled every 5 mintues to S3

example if the following are set

```
cms.event.processors.com.nike.cerberus.event.processor.AuditLogProcessor=true
cms.audit.bucket="athena-test-xxxxxx"
cms.audit.bucket_region="us-west-2"
```

Then the processor and s3 copying will be enabled.

un-minified example of audit log message
```json
{
  "event-timestamp":"2018-01-26 11:35:35",
  "principal-name":"arn:aws:iam::xxxxxxx:role/dev-cerberus-health-check-CerberusHealthCheckRole-xxxxxxx",
  "principal-type":"IAM",
  "principal-token-created":"2018-01-26 11:35:35",
  "principal-token-expires":"2018-01-27 12:35:35",
  "principal-is-admin":"false",
  "ip-address":"22.22.22.22",
  "x-forwarded-for":"33.33.33.33",
  "client-version":"Unknown",
  "http-method":"GET",
  "path":"/v1/secret/app/health-check-bucket/healthcheck",
  "action":"Reading secret with path: /v1/secret/app/health-check-bucket/healthcheck",
  "name":"ReadSecureData Endpoint Called",
  "sdb-name-slug":"health-check-bucket",
  "originating-class":"ReadSecureData"
}
```

The intent is to create a command in the CLI that will create the bucket and configure the Athena table and enable the processor.