### PR TITLE
Fix Dashboard Bug: Wrong download format

### DIFF
--- a/dashboard/app/actions/manageSafetyDepositBoxActions.js
+++ b/dashboard/app/actions/manageSafetyDepositBoxActions.js
@@ -354,7 +354,7 @@ export function downloadFile(token, fullPath, filename) {
     })
         .then((response) => {
             let reader = new window.FileReader();
-            reader.readAsText(response.data);
+            reader.readAsArrayBuffer(response.data);
             reader.onload = function() {
                 downloadjs(reader.result, filename)
             }


### PR DESCRIPTION
This PR fixes an issue where files are downloaded in `Text` format, when they should be downloaded in `Array Buffer` format.

Files are uploaded in `Array Buffer` format, as this line suggests (from previous PR):
https://github.com/Nike-Inc/cerberus-management-service/commit/889b8ad6e91acc8c20a5b623c54ca7fe6782ab71#diff-1836cd3f7f0946782649944ac0ed2f92R138