### PR TITLE
Fix content security policy

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,6 +14,6 @@
 # limitations under the License.
 #
 
-version=3.15.3
+version=3.15.4
 groupId=com.nike.cerberus
 artifactId=cms

--- a/src/main/java/com/nike/cerberus/security/SecurityHttpHeaders.java
+++ b/src/main/java/com/nike/cerberus/security/SecurityHttpHeaders.java
@@ -48,7 +48,7 @@ public class SecurityHttpHeaders extends DefaultHttpHeaders {
      * https://en.wikipedia.org/wiki/Content_Security_Policy
      */
     private static final String CONTENT_SECURITY_POLICY_HEADER_NAME = "Content-Security-Policy";
-    private static final String CONTENT_SECURITY_POLICY_HEADER_VALUE = "default-src 'none'; connect-src 'self'; font-src https://web.nike.com; img-src 'self'; script-src 'self'; style-src 'unsafe-inline' https://web.nike.com/; frame-ancestors 'none';";
+    private static final String CONTENT_SECURITY_POLICY_HEADER_VALUE = "default-src 'none'; connect-src 'self'; font-src https://web.nike.com; img-src 'self'; script-src 'self'; style-src 'unsafe-inline' https://web.nike.com/; worker-src 'self' blob:; frame-ancestors 'none';";
 
     /**
      * Referrer Policy header can restrict referrer information sent by browser


### PR DESCRIPTION
A new Directive is required in the Content Security Policy as a result of the Web Workers added in the previous PR: https://github.com/Nike-Inc/cerberus-management-service/pull/157