### PR TITLE
Increase Hystrix timeout for KMS Encrypt

### DIFF
--- a/src/main/resources/cms.conf
+++ b/src/main/resources/cms.conf
@@ -80,7 +80,7 @@ c3p0.preferredTestQuery=SELECT 1
 
 # Default AWS limit was 1200 shared as of Aug 2017
 hystrix.threadpool.KmsEncryptDecrypt.coreSize=1000
-hystrix.command.KmsEncryptDecrypt.execution.isolation.thread.timeoutInMilliseconds=3000
+hystrix.command.KmsEncrypt.execution.isolation.thread.timeoutInMilliseconds=3000
 
 # Default AWS limit was 5 as of Aug 2017
 hystrix.threadpool.KmsCreateKey.coreSize=5


### PR DESCRIPTION
KMS encrypt calls trigger the following Hystrix 500 error more than 10 times/day:
```
com.netflix.hystrix.exception.HystrixRuntimeException: KmsEncrypt timed-out and no fallback available.
```

The Hystrix system property to increase the KMS encrypt timeout in `cms.conf` seems to be misnamed judging by this Hystrix documentation:
https://github.com/Netflix/Hystrix/wiki/Configuration#execution.isolation.thread.timeoutInMilliseconds

..and judging by these two lines of code:
https://github.com/Nike-Inc/cerberus-management-service/blob/master/src/main/java/com/nike/cerberus/hystrix/HystrixKmsClient.java#L51

https://github.com/Nike-Inc/cerberus-management-service/blob/master/src/main/java/com/nike/cerberus/hystrix/HystrixKmsClient.java#L94