### PR TITLE
Increase timeout for KMS create key calls

### DIFF
--- a/src/main/resources/cms.conf
+++ b/src/main/resources/cms.conf
@@ -84,6 +84,7 @@ hystrix.command.KmsEncrypt.execution.isolation.thread.timeoutInMilliseconds=3000
 
 # Default AWS limit was 5 as of Aug 2017
 hystrix.threadpool.KmsCreateKey.coreSize=5
+hystrix.command.KmsCreateKey.execution.isolation.thread.timeoutInMilliseconds=2000
 
 # Default AWS limit was 5 as of Aug 2017
 hystrix.threadpool.KmsCreateAlias.coreSize=5


### PR DESCRIPTION
Occasionally this call exceeds the default 1000 millisecond timeout and returns a 500 to users, so increase to 2000 milliseconds.