### PR TITLE
* Highlander doesn't require token refresh at SDB creation etc. Howev…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,6 +14,6 @@
 # limitations under the License.
 #
 
-version=3.18.0
+version=3.18.1
 groupId=com.nike.cerberus
 artifactId=cms

--- a/src/main/java/com/nike/cerberus/endpoints/sdb/CreateSafeDepositBoxV1.java
+++ b/src/main/java/com/nike/cerberus/endpoints/sdb/CreateSafeDepositBoxV1.java
@@ -93,7 +93,7 @@ public class CreateSafeDepositBoxV1 extends AuditableEventEndpoint<SafeDepositBo
             return ResponseInfo.newBuilder(map)
                     .withHeaders(new DefaultHttpHeaders()
                             .set(LOCATION, location)
-                            .set(HEADER_X_REFRESH_TOKEN, Boolean.TRUE.toString()))
+                            .set(HEADER_X_REFRESH_TOKEN, Boolean.FALSE.toString()))
                     .withHttpStatusCode(HttpResponseStatus.CREATED.code())
                     .build();
         }

--- a/src/main/java/com/nike/cerberus/endpoints/sdb/CreateSafeDepositBoxV2.java
+++ b/src/main/java/com/nike/cerberus/endpoints/sdb/CreateSafeDepositBoxV2.java
@@ -87,7 +87,7 @@ public class CreateSafeDepositBoxV2 extends AuditableEventEndpoint<SafeDepositBo
             return ResponseInfo.newBuilder(safeDepositBox)
                     .withHeaders(new DefaultHttpHeaders()
                             .set(LOCATION, location)
-                            .set(HEADER_X_REFRESH_TOKEN, Boolean.TRUE.toString()))
+                            .set(HEADER_X_REFRESH_TOKEN, Boolean.FALSE.toString()))
                     .withHttpStatusCode(HttpResponseStatus.CREATED.code())
                     .build();
         }

--- a/src/main/java/com/nike/cerberus/endpoints/sdb/DeleteSafeDepositBox.java
+++ b/src/main/java/com/nike/cerberus/endpoints/sdb/DeleteSafeDepositBox.java
@@ -78,7 +78,7 @@ public class DeleteSafeDepositBox extends AuditableEventEndpoint<Void, Void> {
 
             safeDepositBoxService.deleteSafeDepositBox(authPrincipal, sdbId);
             return ResponseInfo.<Void>newBuilder().withHttpStatusCode(HttpResponseStatus.OK.code())
-                    .withHeaders(new DefaultHttpHeaders().set(HEADER_X_REFRESH_TOKEN, Boolean.TRUE.toString()))
+                    .withHeaders(new DefaultHttpHeaders().set(HEADER_X_REFRESH_TOKEN, Boolean.FALSE.toString()))
                     .build();
         }
 

--- a/src/main/java/com/nike/cerberus/endpoints/sdb/UpdateSafeDepositBoxV1.java
+++ b/src/main/java/com/nike/cerberus/endpoints/sdb/UpdateSafeDepositBoxV1.java
@@ -82,7 +82,7 @@ public class UpdateSafeDepositBoxV1 extends AuditableEventEndpoint<SafeDepositBo
                     authPrincipal,
                     sdbId);
             return ResponseInfo.<Void>newBuilder().withHttpStatusCode(HttpResponseStatus.NO_CONTENT.code())
-                    .withHeaders(new DefaultHttpHeaders().set(HEADER_X_REFRESH_TOKEN, Boolean.TRUE.toString()))
+                    .withHeaders(new DefaultHttpHeaders().set(HEADER_X_REFRESH_TOKEN, Boolean.FALSE.toString()))
                     .build();
         }
 

--- a/src/main/java/com/nike/cerberus/endpoints/sdb/UpdateSafeDepositBoxV2.java
+++ b/src/main/java/com/nike/cerberus/endpoints/sdb/UpdateSafeDepositBoxV2.java
@@ -81,7 +81,7 @@ public class UpdateSafeDepositBoxV2 extends AuditableEventEndpoint<SafeDepositBo
                     authPrincipal,
                     request.getPathParam("id"));
             return ResponseInfo.newBuilder(safeDepositBoxV2)
-                    .withHeaders(new DefaultHttpHeaders().set(HEADER_X_REFRESH_TOKEN, Boolean.TRUE.toString()))
+                    .withHeaders(new DefaultHttpHeaders().set(HEADER_X_REFRESH_TOKEN, Boolean.FALSE.toString()))
                     .withHttpStatusCode(HttpResponseStatus.OK.code())
                     .build();
         }


### PR DESCRIPTION
…er it still sends the X-refresh-token=true header and some client that depend on Vault client (Go client) still acknowledge the header and refresh the token. This behavior cause inconvenience when a user is logged into dashboard at the same time.