### PR TITLE
Make CMS use the region that the request was signed for rather than locking into a single region

### DIFF
--- a/src/main/java/com/nike/cerberus/aws/sts/AwsStsClient.java
+++ b/src/main/java/com/nike/cerberus/aws/sts/AwsStsClient.java
@@ -33,7 +33,7 @@ public class AwsStsClient {
     }
 
     public GetCallerIdentityResponse getCallerIdentity(AwsStsHttpHeader header) {
-        GetCallerIdentityFullResponse response = httpClient.execute(header.generateHeaders(), GetCallerIdentityFullResponse.class);
+        GetCallerIdentityFullResponse response = httpClient.execute(header.getRegion(), header.generateHeaders(), GetCallerIdentityFullResponse.class);
         return response.getGetCallerIdentityResponse();
     }
 }

--- a/src/main/java/com/nike/cerberus/aws/sts/AwsStsHttpClient.java
+++ b/src/main/java/com/nike/cerberus/aws/sts/AwsStsHttpClient.java
@@ -49,7 +49,7 @@ public class AwsStsHttpClient {
 
     private static final MediaType DEFAULT_ACCEPTED_MEDIA_TYPE = MediaType.parse("application/json");
 
-    private static final String DEFAULT_AWS_STS_ENDPOINT = "https://sts.amazonaws.com";
+    private static final String AWS_STS_ENDPOINT_TEMPLATE = "https://sts.%s.amazonaws.com";
 
     private static final String DEFAULT_GET_CALLER_IDENTITY_ACTION = "Action=GetCallerIdentity&Version=2011-06-15";
 
@@ -72,14 +72,16 @@ public class AwsStsHttpClient {
     /**
      * Executes the HTTP request based on the input parameters.
      *
-     * @param headers     HTTP Headers to include in the request
+     * @param region        The region to call sts get caller identity in.
+     * @param headers       HTTP Headers to include in the request
      * @param responseClass The class of the response object
      * @return Response from the server
      */
-    public <M> M execute(final Map<String, String> headers,
-                            final Class<M> responseClass) {
+    public <M> M execute(final String region,
+                         final Map<String, String> headers,
+                         final Class<M> responseClass) {
         try {
-            Request request = buildRequest(headers);
+            Request request = buildRequest(region, headers);
             Response response = executeRequestWithRetry(request, DEFAULT_AUTH_RETRIES, DEFAULT_RETRY_INTERVAL_IN_MILLIS);
             if (response.code() >= 400 && response.code() < 500) {
                 ApiException.Builder builder = ApiException.newBuilder();
@@ -117,8 +119,8 @@ public class AwsStsHttpClient {
      *
      * @throws JsonProcessingException
      */
-    protected Request buildRequest(Map<String, String> headers) {
-        Request.Builder requestBuilder = new Request.Builder().url(DEFAULT_AWS_STS_ENDPOINT)
+    protected Request buildRequest(String region, Map<String, String> headers) {
+        Request.Builder requestBuilder = new Request.Builder().url(String.format(AWS_STS_ENDPOINT_TEMPLATE, region))
                 .addHeader("Accept", DEFAULT_ACCEPTED_MEDIA_TYPE.toString());
 
         if (headers != null) {

--- a/src/test/java/com/nike/cerberus/aws/sts/AwsStsClientTest.java
+++ b/src/test/java/com/nike/cerberus/aws/sts/AwsStsClientTest.java
@@ -33,8 +33,11 @@ public class AwsStsClientTest {
     public void setup() {
         httpClient = mock(AwsStsHttpClient.class);
         awsStsClient = new AwsStsClient(httpClient);
-        awsStsHttpHeader = new AwsStsHttpHeader("test amz date",
-                "test amz security token", "test authorization");
+        awsStsHttpHeader = new AwsStsHttpHeader(
+                "test amz date",
+                "test amz security token",
+                "AWS4-HMAC-SHA256 Credential=ASIA5S2FQS2GYQLK5FFF/20180904/us-west-2/sts/aws4_request, SignedHeaders=host;x-amz-date, Signature=ddb9417d2b9bfe6f8b03e31a8f5d8ab98e0f4alkj12312098asdf"
+        );
     }
 
     @Test
@@ -44,7 +47,7 @@ public class AwsStsClientTest {
 
         GetCallerIdentityFullResponse response = mock(GetCallerIdentityFullResponse.class);
 
-        when(httpClient.execute(awsStsHttpHeader.generateHeaders(), GetCallerIdentityFullResponse.class))
+        when(httpClient.execute(awsStsHttpHeader.getRegion(), awsStsHttpHeader.generateHeaders(), GetCallerIdentityFullResponse.class))
                 .thenReturn(response);
 
         // invoke method under test
@@ -57,7 +60,7 @@ public class AwsStsClientTest {
 
         GetCallerIdentityFullResponse response = new GetCallerIdentityFullResponse();
 
-        when(httpClient.execute(awsStsHttpHeader.generateHeaders(), GetCallerIdentityFullResponse.class))
+        when(httpClient.execute(awsStsHttpHeader.getRegion(), awsStsHttpHeader.generateHeaders(), GetCallerIdentityFullResponse.class))
                 .thenReturn(response);
     }
 }

--- a/src/test/java/com/nike/cerberus/aws/sts/AwsStsHttpClientTest.java
+++ b/src/test/java/com/nike/cerberus/aws/sts/AwsStsHttpClientTest.java
@@ -66,7 +66,7 @@ public class AwsStsHttpClientTest {
         when(httpClient.newCall(any())).thenReturn(call);
 
         // invoke method under test
-        awsStsHttpClient.execute(null, GetCallerIdentityFullResponse.class);
+        awsStsHttpClient.execute(null, null, GetCallerIdentityFullResponse.class);
     }
 
     @Test(expected = ApiException.class)
@@ -77,7 +77,7 @@ public class AwsStsHttpClientTest {
         when(httpClient.newCall(any())).thenReturn(call);
 
         // invoke method under test
-        awsStsHttpClient.execute(null, GetCallerIdentityFullResponse.class);
+        awsStsHttpClient.execute(null, null, GetCallerIdentityFullResponse.class);
     }
 
     @Test
@@ -85,10 +85,10 @@ public class AwsStsHttpClientTest {
         String method = "POST";
 
         // invoke method under test
-        Request request = awsStsHttpClient.buildRequest(Maps.newHashMap());
+        Request request = awsStsHttpClient.buildRequest("us-west-2", Maps.newHashMap());
 
         assertEquals(2, request.headers().size());
-        assertEquals("https://sts.amazonaws.com/", request.url().uri().toString());
+        assertEquals("https://sts.us-west-2.amazonaws.com/", request.url().uri().toString());
         assertEquals(method, request.method());
         assertEquals(43, request.body().contentLength());
     }
@@ -125,7 +125,7 @@ public class AwsStsHttpClientTest {
         when(httpClient.newCall(any())).thenReturn(call);
 
         // invoke method under test
-        awsStsHttpClient.execute(null, GetCallerIdentityFullResponse.class);
+        awsStsHttpClient.execute(null, null, GetCallerIdentityFullResponse.class);
     }
 
     @Test
@@ -137,7 +137,7 @@ public class AwsStsHttpClientTest {
         when(successCall.execute()).thenReturn(createFakeResponse(200, "test arn"));
 
         when(httpClient.newCall(any())).thenReturn(successCall).thenReturn(failCall);
-        GetCallerIdentityFullResponse actualResponse = awsStsHttpClient.execute(null, GetCallerIdentityFullResponse.class);
+        GetCallerIdentityFullResponse actualResponse = awsStsHttpClient.execute(null, null, GetCallerIdentityFullResponse.class);
         assertThat(actualResponse).isNotNull();
         assertThat(actualResponse.getGetCallerIdentityResponse().getGetCallerIdentityResult().getArn()).isEqualToIgnoringCase("test arn");
     }
@@ -151,7 +151,7 @@ public class AwsStsHttpClientTest {
         when(successCall.execute()).thenReturn(createFakeResponse(200, "test arn"));
 
         when(httpClient.newCall(any())).thenReturn(failCall).thenReturn(successCall);
-        GetCallerIdentityFullResponse actualResponse = awsStsHttpClient.execute(null, GetCallerIdentityFullResponse.class);
+        GetCallerIdentityFullResponse actualResponse = awsStsHttpClient.execute(null, null, GetCallerIdentityFullResponse.class);
         assertThat(actualResponse).isNotNull();
         assertThat(actualResponse.getGetCallerIdentityResponse().getGetCallerIdentityResult().getArn()).isEqualToIgnoringCase("test arn");
     }
@@ -167,7 +167,7 @@ public class AwsStsHttpClientTest {
         when(successCall.execute()).thenReturn(createFakeResponse(200, "test arn"));
 
         when(httpClient.newCall(any())).thenReturn(failCall).thenReturn(failCall).thenReturn(successCall);
-        GetCallerIdentityFullResponse actualResponse = awsStsHttpClient.execute(null, GetCallerIdentityFullResponse.class);
+        GetCallerIdentityFullResponse actualResponse = awsStsHttpClient.execute(null, null, GetCallerIdentityFullResponse.class);
         assertThat(actualResponse).isNotNull();
         assertThat(actualResponse.getGetCallerIdentityResponse().getGetCallerIdentityResult().getArn()).isEqualToIgnoringCase("test arn");
     }

--- a/src/test/java/com/nike/cerberus/aws/sts/AwsStsHttpHeaderTest.java
+++ b/src/test/java/com/nike/cerberus/aws/sts/AwsStsHttpHeaderTest.java
@@ -1,0 +1,28 @@
+package com.nike.cerberus.aws.sts;
+
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertEquals;
+
+public class AwsStsHttpHeaderTest {
+
+    @Test
+    public void test_getRegion_returns_region_as_expected() {
+        AwsStsHttpHeader header = new AwsStsHttpHeader(
+                "20180904T205115Z",
+                "FQoGZXIvYXdzEFYaDEYceadsfLKJLKlkj908098oB/rJIdxdo57fx3Ef2wW8WhFbSpLGg3hwNqhuepdkf/c0F7OXJutqM2yjgnZCiO7SPAdnMSJhoEgH7SJlkPaPfiRzZAf0yxxD6e4z0VJU74uQfbgfZpn5RL+JyDpgoYkUrjuyL8zRB1knGSOCi32Q75+asdfasd+7bWxMyJIKEb/HF2Le8xM/9F4WRqa5P0+asdfasdfasdf+MGlDlNG0KTzg1JT6QXf95ozWR5bBFSz5DbrFhXhMegMQ7+7Kvx+asdfasdl.jlkj++5NpRRlE54cct7+aG3HQskow9y73AU=",
+                "AWS4-HMAC-SHA256 Credential=ASIA5S2FQS2GYQLK5FFF/20180904/us-west-2/sts/aws4_request, SignedHeaders=host;x-amz-date, Signature=ddb9417d2b9bfe6f8b03e31a8f5d8ab98e0f4alkj12312098asdf"
+        );
+
+        assertEquals("us-west-2", header.getRegion());
+
+        header = new AwsStsHttpHeader(
+                "20180904T205115Z",
+                "FQoGZXIvYXdzEFYaDEYceadsfLKJLKlkj908098oB/rJIdxdo57fx3Ef2wW8WhFbSpLGg3hwNqhuepdkf/c0F7OXJutqM2yjgnZCiO7SPAdnMSJhoEgH7SJlkPaPfiRzZAf0yxxD6e4z0VJU74uQfbgfZpn5RL+JyDpgoYkUrjuyL8zRB1knGSOCi32Q75+asdfasd+7bWxMyJIKEb/HF2Le8xM/9F4WRqa5P0+asdfasdfasdf+MGlDlNG0KTzg1JT6QXf95ozWR5bBFSz5DbrFhXhMegMQ7+7Kvx+asdfasdl.jlkj++5NpRRlE54cct7+aG3HQskow9y73AU=",
+                "AWS4-HMAC-SHA256 Credential=ASIA5S2FQS2GYQLK5FFF/20180904/us-east-1/sts/aws4_request, SignedHeaders=host;x-amz-date, Signature=ddb9417d2b9bfe6f8b03e31a8f5d8ab98e0f4alkj12312098asdf"
+        );
+
+        assertEquals("us-east-1", header.getRegion());
+    }
+
+}


### PR DESCRIPTION
Unit tested and UA Tested with the following script.

```bash
#!/usr/bin/env bash

# This script assumes that REGION and API_HOST are set externally 
# ex: REGION='us-west-2' API_HOST=http://localhost:8080/v2/auth/sts-identity path/to/this/script

timestamp="$( LC_ALL=C gdate -u "+%Y-%m-%d %H:%M:%S" )"

iso_timestamp=$(gdate -ud "${timestamp}" "+%Y%m%dT%H%M%SZ")
date_scope=$(gdate -ud "${timestamp}" "+%Y%m%d")
date_header=$(gdate -ud "${timestamp}" "+%a, %d %h %Y %T %Z")

awsAccessKey=$AWS_ACCESS_KEY_ID
awsSecretKey=$AWS_SECRET_ACCESS_KEY
awsSecuToken=$AWS_SESSION_TOKEN

signedHeader='host;x-amz-date'

postPayload='Action=GetCallerIdentity&Version=2011-06-15'

canonical_request()
{
  echo "POST"
  echo "/"
  echo ""
  echo "host:sts.${REGION}.amazonaws.com"
  echo "x-amz-date:${iso_timestamp}"
  echo ""
  echo "${signedHeader}"

  sum=$(echo -n ${postPayload} | shasum -a 256)
  printf ${sum%% *}
}

canonical_request_hash()
{
  local output=$(canonical_request | shasum -a 256)
  echo "${output%% *}"
}

string_to_sign()
{
  echo "AWS4-HMAC-SHA256"
  echo "${iso_timestamp}"
  echo "${date_scope}/${REGION}/sts/aws4_request"
  printf "$(canonical_request_hash)"
}

signature_key()
{
  local secret=$(printf "AWS4${awsSecretKey}" | hex_key)
  local date_key=$(printf ${date_scope} | hmac_sha256 "${secret}" | hex_key)
  local region_key=$(printf ${REGION} | hmac_sha256 "${date_key}" | hex_key)
  local service_key=$(printf "sts" | hmac_sha256 "${region_key}" | hex_key)
  printf "aws4_request" | hmac_sha256 "${service_key}" | hex_key
}

hex_key() {
  xxd -p -c 256
}

hmac_sha256() {
  local hexkey=$1
  openssl dgst -binary -sha256 -mac HMAC -macopt hexkey:${hexkey}
}

signature() {
  string_to_sign | hmac_sha256 $(signature_key) | hex_key | sed "s/^.* //"
}

curl -v \
  -X 'POST' \
  -H "Accept: application/json" \
  -H "Authorization: AWS4-HMAC-SHA256 Credential=${awsAccessKey}/${date_scope}/${REGION}/sts/aws4_request, SignedHeaders=${signedHeader}, Signature=$(signature)" \
  -H "Date: Thu, 09 Aug 2018 00:36:14 GMT" \
  -H "x-amz-date: ${iso_timestamp}" \
  -H "x-amz-security-token:${awsSecuToken}" \
  -d "Action=GetCallerIdentity&Version=2011-06-15" \
  "${API_HOST}"
```
