### PR TITLE
Source hostname from InetAddress as the HOSTNAME env var is not alway…

### DIFF
--- a/src/main/resources/logback.groovy
+++ b/src/main/resources/logback.groovy
@@ -205,7 +205,7 @@ logger("ACCESS_LOG", accessLogLevel, allAsyncAccessLogAppendersArray, false)
 
 // Auditable Events
 if (ConfigService.getInstance().isAuditLoggingEnabled()) {
-    def hostname = System.getenv('HOSTNAME')
+    def hostname = System.getenv('HOSTNAME') ? System.getenv('HOSTNAME') : InetAddress.getLocalHost().getHostName()
     appender("audit-log-appender", FiveMinuteRollingFileAppender) {
         file = "${LOG_FILE_DIRECTORY_PATH}/${hostname}-audit.log"
 


### PR DESCRIPTION
…s set

I noticed in Unbuntu 16.04 that the hostname portion of the audit logs where coming in as null.

![image](https://user-images.githubusercontent.com/711726/51778406-57c25100-20b6-11e9-9dac-d8d8f59b0949.png)

Using Inet seems to be a more reliable method.