### PR TITLE
refactor: Made Riposte endpoint be annotation based.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-- oraclejdk8
+- openjdk8
 after_success:
 - ./gradlew jacocoTestReport coveralls
 deploy:

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -84,7 +84,7 @@ dependencies {
             "junit:junit:4.12",
             "org.assertj:assertj-core:3.0.0",
             "org.mockito:mockito-all:1.10.8",
-            "com.nike.backstopper:backstopper-reusable-tests:0.11.1",
+            "com.nike.backstopper:backstopper-reusable-tests:0.11.5",
             'com.openpojo:openpojo:0.8.4'
     )
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -75,7 +75,8 @@ dependencies {
             "com.okta:okta-sdk:0.0.4",
             "com.okta.authn.sdk:okta-authn-sdk-api:0.1.0",
             "com.okta.sdk:okta-sdk-httpclient:1.2.0",
-            "com.okta.authn.sdk:okta-authn-sdk-impl:0.1.0"
+            "com.okta.authn.sdk:okta-authn-sdk-impl:0.1.0",
+            "org.reflections:reflections:0.9.11"
 
     )
 

--- a/src/main/java/com/nike/cerberus/endpoints/GetDashboard.java
+++ b/src/main/java/com/nike/cerberus/endpoints/GetDashboard.java
@@ -49,6 +49,7 @@ import static com.nike.cerberus.CerberusHttpHeaders.getXForwardedClientIp;
 /**
  * Endpoint for loading the dashboard and associated static assets.
  */
+@RiposteEndpoint
 public class GetDashboard extends StandardEndpoint<Void, byte[]> {
 
     private final Logger logger = LoggerFactory.getLogger(getClass());

--- a/src/main/java/com/nike/cerberus/endpoints/GetDashboardRedirect.java
+++ b/src/main/java/com/nike/cerberus/endpoints/GetDashboardRedirect.java
@@ -35,6 +35,7 @@ import static com.nike.cerberus.endpoints.GetDashboard.DASHBOARD_ENDPOINT;
 /**
  * Redirect endpoint to the dashboard.
  */
+@RiposteEndpoint
 public class GetDashboardRedirect extends StandardEndpoint<Void, Void> {
 
     @Override

--- a/src/main/java/com/nike/cerberus/endpoints/HealthCheckEndpoint.java
+++ b/src/main/java/com/nike/cerberus/endpoints/HealthCheckEndpoint.java
@@ -32,6 +32,7 @@ import java.util.concurrent.Executor;
  *
  * @author Nic Munroe
  */
+@RiposteEndpoint
 public class HealthCheckEndpoint extends StandardEndpoint<Void, String> {
     @Override
     public CompletableFuture<ResponseInfo<String>> execute(RequestInfo<Void> request, Executor longRunningTaskExecutor, ChannelHandlerContext ctx) {

--- a/src/main/java/com/nike/cerberus/endpoints/RiposteEndpoint.java
+++ b/src/main/java/com/nike/cerberus/endpoints/RiposteEndpoint.java
@@ -1,0 +1,14 @@
+package com.nike.cerberus.endpoints;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation that can be used to mark classes as Riposte endpoints and have them bootstrapped into the Guice module.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface RiposteEndpoint {
+}

--- a/src/main/java/com/nike/cerberus/endpoints/RobotsEndpoint.java
+++ b/src/main/java/com/nike/cerberus/endpoints/RobotsEndpoint.java
@@ -28,6 +28,7 @@ import java.util.concurrent.Executor;
 /**
  * robots.txt that says never index this site
  */
+@RiposteEndpoint
 public class RobotsEndpoint extends StandardEndpoint<Void, String> {
 
     private static final String ROBOTS_DISALLOW = "User-agent: *\nDisallow: /";

--- a/src/main/java/com/nike/cerberus/endpoints/admin/GetAuthKmsKeyMetadata.java
+++ b/src/main/java/com/nike/cerberus/endpoints/admin/GetAuthKmsKeyMetadata.java
@@ -2,6 +2,7 @@ package com.nike.cerberus.endpoints.admin;
 
 import com.nike.cerberus.domain.AuthKmsKeyMetadataResult;
 import com.nike.cerberus.endpoints.AdminStandardEndpoint;
+import com.nike.cerberus.endpoints.RiposteEndpoint;
 import com.nike.cerberus.service.KmsService;
 import com.nike.riposte.server.http.RequestInfo;
 import com.nike.riposte.server.http.ResponseInfo;
@@ -19,6 +20,7 @@ import java.util.concurrent.Executor;
 /**
  * Endpoint for retrieving kms key metadata for all created keys in the db
  */
+@RiposteEndpoint
 public class GetAuthKmsKeyMetadata extends AdminStandardEndpoint<Void, AuthKmsKeyMetadataResult> {
 
     private final KmsService kmsService;

--- a/src/main/java/com/nike/cerberus/endpoints/admin/GetSDBMetadata.java
+++ b/src/main/java/com/nike/cerberus/endpoints/admin/GetSDBMetadata.java
@@ -19,6 +19,7 @@ package com.nike.cerberus.endpoints.admin;
 import com.google.inject.Inject;
 import com.nike.cerberus.domain.SDBMetadataResult;
 import com.nike.cerberus.endpoints.AdminStandardEndpoint;
+import com.nike.cerberus.endpoints.RiposteEndpoint;
 import com.nike.cerberus.service.MetadataService;
 import com.nike.cerberus.service.PaginationService;
 import com.nike.riposte.server.http.RequestInfo;
@@ -36,6 +37,7 @@ import java.util.concurrent.Executor;
 /**
  * Returns meta data for all SDBs in CMS
  */
+@RiposteEndpoint
 public class GetSDBMetadata extends AdminStandardEndpoint<Void, SDBMetadataResult> {
 
     private final MetadataService metadataService;

--- a/src/main/java/com/nike/cerberus/endpoints/admin/OverrideSdbOwner.java
+++ b/src/main/java/com/nike/cerberus/endpoints/admin/OverrideSdbOwner.java
@@ -19,6 +19,7 @@ package com.nike.cerberus.endpoints.admin;
 import com.google.inject.Inject;
 import com.nike.cerberus.domain.SDBMetadata;
 import com.nike.cerberus.endpoints.AdminStandardEndpoint;
+import com.nike.cerberus.endpoints.RiposteEndpoint;
 import com.nike.cerberus.endpoints.CustomizableAuditData;
 import com.nike.cerberus.security.CerberusPrincipal;
 import com.nike.cerberus.service.SafeDepositBoxService;
@@ -41,6 +42,7 @@ import java.util.concurrent.Executor;
 /**
  * Allows an Admin to override the owner of an SDB
  */
+@RiposteEndpoint
 public class OverrideSdbOwner extends AdminStandardEndpoint<SDBMetadata, Void> {
 
     private final Logger log = LoggerFactory.getLogger(getClass());

--- a/src/main/java/com/nike/cerberus/endpoints/admin/PutSDBMetadata.java
+++ b/src/main/java/com/nike/cerberus/endpoints/admin/PutSDBMetadata.java
@@ -19,6 +19,7 @@ package com.nike.cerberus.endpoints.admin;
 import com.google.inject.Inject;
 import com.nike.cerberus.domain.SDBMetadata;
 import com.nike.cerberus.endpoints.AdminStandardEndpoint;
+import com.nike.cerberus.endpoints.RiposteEndpoint;
 import com.nike.cerberus.security.CerberusPrincipal;
 import com.nike.cerberus.service.MetadataService;
 import com.nike.riposte.server.http.RequestInfo;
@@ -38,6 +39,7 @@ import java.util.concurrent.Executor;
 /**
  * Allows an Admin to restore (create or update) Metadata for an SDB
  */
+@RiposteEndpoint
 public class PutSDBMetadata extends AdminStandardEndpoint<SDBMetadata, Void> {
 
     private final Logger log = LoggerFactory.getLogger(getClass());

--- a/src/main/java/com/nike/cerberus/endpoints/admin/RestoreSafeDepositBox.java
+++ b/src/main/java/com/nike/cerberus/endpoints/admin/RestoreSafeDepositBox.java
@@ -20,6 +20,7 @@ package com.nike.cerberus.endpoints.admin;
 import com.google.inject.Inject;
 import com.nike.cerberus.domain.SDBMetadata;
 import com.nike.cerberus.endpoints.AdminStandardEndpoint;
+import com.nike.cerberus.endpoints.RiposteEndpoint;
 import com.nike.cerberus.security.CerberusPrincipal;
 import com.nike.cerberus.service.MetadataService;
 import com.nike.cerberus.service.SecureDataService;
@@ -41,6 +42,7 @@ import java.util.concurrent.Executor;
 /**
  * Allows an Admin to restore (create or update) Metadata for an SDB
  */
+@RiposteEndpoint
 public class RestoreSafeDepositBox extends AdminStandardEndpoint<SDBMetadata, Void> {
 
     private final Logger log = LoggerFactory.getLogger(getClass());

--- a/src/main/java/com/nike/cerberus/endpoints/admin/TriggerScheduledJob.java
+++ b/src/main/java/com/nike/cerberus/endpoints/admin/TriggerScheduledJob.java
@@ -18,6 +18,7 @@ package com.nike.cerberus.endpoints.admin;
 
 import com.nike.backstopper.exception.ApiException;
 import com.nike.cerberus.endpoints.AdminStandardEndpoint;
+import com.nike.cerberus.endpoints.RiposteEndpoint;
 import com.nike.cerberus.error.DefaultApiError;
 import com.nike.riposte.server.http.RequestInfo;
 import com.nike.riposte.server.http.ResponseInfo;
@@ -35,6 +36,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
+@RiposteEndpoint
 public class TriggerScheduledJob extends AdminStandardEndpoint<Void, Void> {
 
     private final Logger log = LoggerFactory.getLogger(getClass());

--- a/src/main/java/com/nike/cerberus/endpoints/authentication/AuthenticateIamPrincipal.java
+++ b/src/main/java/com/nike/cerberus/endpoints/authentication/AuthenticateIamPrincipal.java
@@ -21,6 +21,7 @@ import com.nike.backstopper.apierror.ApiError;
 import com.nike.backstopper.exception.ApiException;
 import com.nike.cerberus.domain.IamPrincipalCredentials;
 import com.nike.cerberus.domain.IamRoleAuthResponse;
+import com.nike.cerberus.endpoints.RiposteEndpoint;
 import com.nike.cerberus.service.AuthenticationService;
 import com.nike.cerberus.service.EventProcessorService;
 import com.nike.riposte.server.http.RequestInfo;
@@ -42,6 +43,7 @@ import static com.nike.cerberus.endpoints.AuditableEventEndpoint.auditableEvent;
  * Authentication endpoint for IAM roles.  If valid, a client token that is encrypted via KMS is returned.  The
  * IAM role will be the only role capable of decrypting the client token via KMS.
  */
+@RiposteEndpoint
 public class AuthenticateIamPrincipal extends StandardEndpoint<IamPrincipalCredentials, IamRoleAuthResponse> {
 
     private final AuthenticationService authenticationService;

--- a/src/main/java/com/nike/cerberus/endpoints/authentication/AuthenticateIamRole.java
+++ b/src/main/java/com/nike/cerberus/endpoints/authentication/AuthenticateIamRole.java
@@ -20,6 +20,7 @@ import com.nike.backstopper.apierror.ApiError;
 import com.nike.backstopper.exception.ApiException;
 import com.nike.cerberus.domain.IamRoleAuthResponse;
 import com.nike.cerberus.domain.IamRoleCredentials;
+import com.nike.cerberus.endpoints.RiposteEndpoint;
 import com.nike.cerberus.service.AuthenticationService;
 import com.nike.cerberus.service.EventProcessorService;
 import com.nike.cerberus.util.AwsIamRoleArnParser;
@@ -45,6 +46,7 @@ import static com.nike.cerberus.endpoints.AuditableEventEndpoint.auditableEvent;
  * IAM role will be the only role capable of decrypting the client token via KMS.
  */
 @Deprecated
+@RiposteEndpoint
 public class AuthenticateIamRole extends StandardEndpoint<IamRoleCredentials, IamRoleAuthResponse> {
 
     private final Logger log = LoggerFactory.getLogger(getClass());

--- a/src/main/java/com/nike/cerberus/endpoints/authentication/AuthenticateStsIdentity.java
+++ b/src/main/java/com/nike/cerberus/endpoints/authentication/AuthenticateStsIdentity.java
@@ -23,6 +23,7 @@ import com.nike.cerberus.aws.sts.AwsStsClient;
 import com.nike.cerberus.aws.sts.AwsStsHttpHeader;
 import com.nike.cerberus.aws.sts.GetCallerIdentityResponse;
 import com.nike.cerberus.domain.AuthTokenResponse;
+import com.nike.cerberus.endpoints.RiposteEndpoint;
 import com.nike.cerberus.error.DefaultApiError;
 import com.nike.cerberus.service.AuthenticationService;
 import com.nike.cerberus.service.EventProcessorService;
@@ -47,6 +48,7 @@ import static com.nike.cerberus.endpoints.AuditableEventEndpoint.auditableEvent;
  * Authentication endpoint for IAM roles.  If valid, a client token that is encrypted via KMS is returned.  The
  * IAM role will be the only role capable of decrypting the client token via KMS.
  */
+@RiposteEndpoint
 public class AuthenticateStsIdentity extends StandardEndpoint<Void, AuthTokenResponse> {
 
     private final AuthenticationService authenticationService;

--- a/src/main/java/com/nike/cerberus/endpoints/authentication/AuthenticateUser.java
+++ b/src/main/java/com/nike/cerberus/endpoints/authentication/AuthenticateUser.java
@@ -19,6 +19,7 @@ package com.nike.cerberus.endpoints.authentication;
 import com.nike.backstopper.exception.ApiException;
 import com.nike.cerberus.auth.connector.AuthResponse;
 import com.nike.cerberus.domain.UserCredentials;
+import com.nike.cerberus.endpoints.RiposteEndpoint;
 import com.nike.cerberus.error.DefaultApiError;
 import com.nike.cerberus.service.AuthenticationService;
 import com.nike.cerberus.service.EventProcessorService;
@@ -31,8 +32,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpMethod;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.ArrayUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.ws.rs.core.HttpHeaders;
@@ -45,6 +44,7 @@ import static com.nike.cerberus.endpoints.AuditableEventEndpoint.auditableEvent;
 /**
  * Authentication endpoint for user credentials.  If valid, a client token will be returned.
  */
+@RiposteEndpoint
 public class AuthenticateUser extends StandardEndpoint<Void, AuthResponse> {
 
     private final AuthenticationService authenticationService;

--- a/src/main/java/com/nike/cerberus/endpoints/authentication/CodeHandlingMfaCheck.java
+++ b/src/main/java/com/nike/cerberus/endpoints/authentication/CodeHandlingMfaCheck.java
@@ -18,6 +18,7 @@ package com.nike.cerberus.endpoints.authentication;
 
 import com.nike.cerberus.auth.connector.AuthResponse;
 import com.nike.cerberus.domain.MfaCheckRequest;
+import com.nike.cerberus.endpoints.RiposteEndpoint;
 import com.nike.cerberus.service.AuthenticationService;
 import com.nike.riposte.server.http.RequestInfo;
 import com.nike.riposte.server.http.ResponseInfo;
@@ -35,6 +36,7 @@ import java.util.concurrent.Executor;
 /**
  * Endpoint for verifying the token from the user's MFA device.  Returns the full auth response if verified.
  */
+@RiposteEndpoint
 public class CodeHandlingMfaCheck extends StandardEndpoint<MfaCheckRequest, AuthResponse> {
 
     private final AuthenticationService authenticationService;

--- a/src/main/java/com/nike/cerberus/endpoints/authentication/RefreshUserToken.java
+++ b/src/main/java/com/nike/cerberus/endpoints/authentication/RefreshUserToken.java
@@ -19,6 +19,7 @@ package com.nike.cerberus.endpoints.authentication;
 import com.nike.backstopper.exception.ApiException;
 import com.nike.cerberus.auth.connector.AuthResponse;
 import com.nike.cerberus.endpoints.AuditableEventEndpoint;
+import com.nike.cerberus.endpoints.RiposteEndpoint;
 import com.nike.cerberus.error.DefaultApiError;
 import com.nike.cerberus.security.CmsRequestSecurityValidator;
 import com.nike.cerberus.security.CerberusPrincipal;
@@ -39,6 +40,7 @@ import java.util.concurrent.Executor;
 /**
  * Authentication endpoint that allows refreshing the user token to pickup any permission changes.
  */
+@RiposteEndpoint
 public class RefreshUserToken extends AuditableEventEndpoint<Void, AuthResponse> {
 
     private final AuthenticationService authenticationService;

--- a/src/main/java/com/nike/cerberus/endpoints/authentication/RevokeToken.java
+++ b/src/main/java/com/nike/cerberus/endpoints/authentication/RevokeToken.java
@@ -18,6 +18,7 @@ package com.nike.cerberus.endpoints.authentication;
 
 import com.nike.backstopper.exception.ApiException;
 import com.nike.cerberus.endpoints.AuditableEventEndpoint;
+import com.nike.cerberus.endpoints.RiposteEndpoint;
 import com.nike.cerberus.error.DefaultApiError;
 import com.nike.cerberus.security.CmsRequestSecurityValidator;
 import com.nike.cerberus.security.CerberusPrincipal;
@@ -39,6 +40,7 @@ import java.util.concurrent.Executor;
 /**
  * Revokes the token supplied in the token header.
  */
+@RiposteEndpoint
 public class RevokeToken extends AuditableEventEndpoint<Void, Void> {
 
     private final AuthenticationService authenticationService;

--- a/src/main/java/com/nike/cerberus/endpoints/category/CreateCategory.java
+++ b/src/main/java/com/nike/cerberus/endpoints/category/CreateCategory.java
@@ -20,6 +20,7 @@ import com.nike.backstopper.apierror.sample.SampleCoreApiError;
 import com.nike.backstopper.exception.ApiException;
 import com.nike.cerberus.domain.Category;
 import com.nike.cerberus.endpoints.AdminStandardEndpoint;
+import com.nike.cerberus.endpoints.RiposteEndpoint;
 import com.nike.cerberus.service.CategoryService;
 import com.nike.riposte.server.http.RequestInfo;
 import com.nike.riposte.server.http.ResponseInfo;
@@ -39,6 +40,7 @@ import static io.netty.handler.codec.http.HttpHeaders.Names.LOCATION;
 /**
  * Creates a category and returns a location header.
  */
+@RiposteEndpoint
 public class CreateCategory extends AdminStandardEndpoint<Category, Void> {
 
     public static final String CATEGORY_PATH = "/v1/category";

--- a/src/main/java/com/nike/cerberus/endpoints/category/DeleteCategory.java
+++ b/src/main/java/com/nike/cerberus/endpoints/category/DeleteCategory.java
@@ -17,6 +17,7 @@
 package com.nike.cerberus.endpoints.category;
 
 import com.nike.cerberus.endpoints.AdminStandardEndpoint;
+import com.nike.cerberus.endpoints.RiposteEndpoint;
 import com.nike.cerberus.service.CategoryService;
 import com.nike.riposte.server.http.RequestInfo;
 import com.nike.riposte.server.http.ResponseInfo;
@@ -34,6 +35,7 @@ import java.util.concurrent.Executor;
 /**
  * Deletes the category for the specified ID.  Admin only operation.
  */
+@RiposteEndpoint
 public class DeleteCategory extends AdminStandardEndpoint<Void, Void> {
 
     public static final String PATH_PARAM_ID = "id";

--- a/src/main/java/com/nike/cerberus/endpoints/category/GetAllCategories.java
+++ b/src/main/java/com/nike/cerberus/endpoints/category/GetAllCategories.java
@@ -17,6 +17,7 @@
 package com.nike.cerberus.endpoints.category;
 
 import com.nike.cerberus.domain.Category;
+import com.nike.cerberus.endpoints.RiposteEndpoint;
 import com.nike.cerberus.service.CategoryService;
 import com.nike.riposte.server.http.RequestInfo;
 import com.nike.riposte.server.http.ResponseInfo;
@@ -34,6 +35,7 @@ import java.util.concurrent.Executor;
 /**
  * Returns all known categories.
  */
+@RiposteEndpoint
 public class GetAllCategories extends StandardEndpoint<Void, List<Category>> {
 
     private final CategoryService categoryService;

--- a/src/main/java/com/nike/cerberus/endpoints/category/GetCategory.java
+++ b/src/main/java/com/nike/cerberus/endpoints/category/GetCategory.java
@@ -17,6 +17,7 @@
 package com.nike.cerberus.endpoints.category;
 
 import com.nike.cerberus.domain.Category;
+import com.nike.cerberus.endpoints.RiposteEndpoint;
 import com.nike.cerberus.service.CategoryService;
 import com.nike.riposte.server.http.RequestInfo;
 import com.nike.riposte.server.http.ResponseInfo;
@@ -35,6 +36,7 @@ import java.util.concurrent.Executor;
 /**
  * Returns the category for the specified ID if found, otherwise not found response.
  */
+@RiposteEndpoint
 public class GetCategory extends StandardEndpoint<Void, Category> {
 
     public static final String PATH_PARAM_ID = "id";

--- a/src/main/java/com/nike/cerberus/endpoints/file/DeleteSecureFile.java
+++ b/src/main/java/com/nike/cerberus/endpoints/file/DeleteSecureFile.java
@@ -24,6 +24,7 @@ import com.nike.cerberus.domain.SecureDataRequestInfo;
 import com.nike.cerberus.domain.SecureDataType;
 import com.nike.cerberus.endpoints.AuditableEventEndpoint;
 import com.nike.cerberus.endpoints.CustomizableAuditData;
+import com.nike.cerberus.endpoints.RiposteEndpoint;
 import com.nike.cerberus.error.DefaultApiError;
 import com.nike.cerberus.security.CmsRequestSecurityValidator;
 import com.nike.cerberus.service.SecureDataService;
@@ -48,6 +49,7 @@ import static com.nike.cerberus.endpoints.file.WriteSecureFile.BASE_PATH;
 /**
  * Deletes the given secure file.
  */
+@RiposteEndpoint
 public class DeleteSecureFile extends AuditableEventEndpoint<Void, Void> {
 
     private final Logger log = LoggerFactory.getLogger(getClass());

--- a/src/main/java/com/nike/cerberus/endpoints/file/GetSecureFiles.java
+++ b/src/main/java/com/nike/cerberus/endpoints/file/GetSecureFiles.java
@@ -22,6 +22,7 @@ import com.nike.cerberus.SecureDataRequestService;
 import com.nike.cerberus.domain.SecureDataRequestInfo;
 import com.nike.cerberus.domain.SecureFileSummaryResult;
 import com.nike.cerberus.endpoints.AuditableEventEndpoint;
+import com.nike.cerberus.endpoints.RiposteEndpoint;
 import com.nike.cerberus.service.PaginationService;
 import com.nike.cerberus.service.SecureDataService;
 import com.nike.riposte.server.http.RequestInfo;
@@ -40,6 +41,7 @@ import java.util.concurrent.Executor;
 /**
  * Lists metadata for all files under the given path.
  */
+@RiposteEndpoint
 public class GetSecureFiles extends AuditableEventEndpoint<Void, SecureFileSummaryResult> {
 
     public static final String BASE_PATH = "/v1/secure-files";

--- a/src/main/java/com/nike/cerberus/endpoints/file/HeadSecureFile.java
+++ b/src/main/java/com/nike/cerberus/endpoints/file/HeadSecureFile.java
@@ -23,6 +23,7 @@ import com.nike.cerberus.SecureDataRequestService;
 import com.nike.cerberus.domain.SecureDataRequestInfo;
 import com.nike.cerberus.domain.SecureFileSummary;
 import com.nike.cerberus.endpoints.AuditableEventEndpoint;
+import com.nike.cerberus.endpoints.RiposteEndpoint;
 import com.nike.cerberus.error.DefaultApiError;
 import com.nike.cerberus.service.SecureDataService;
 import com.nike.riposte.server.http.RequestInfo;
@@ -46,6 +47,7 @@ import java.util.concurrent.Executor;
 import static com.nike.cerberus.endpoints.file.WriteSecureFile.BASE_PATH;
 import static javax.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM;
 
+@RiposteEndpoint
 public class HeadSecureFile extends AuditableEventEndpoint<Void, Void> {
 
     private final SecureDataService secureDataService;

--- a/src/main/java/com/nike/cerberus/endpoints/file/ReadSecureFile.java
+++ b/src/main/java/com/nike/cerberus/endpoints/file/ReadSecureFile.java
@@ -24,6 +24,7 @@ import com.nike.cerberus.domain.SecureDataRequestInfo;
 import com.nike.cerberus.domain.SecureFile;
 import com.nike.cerberus.domain.SecureFileVersion;
 import com.nike.cerberus.endpoints.AuditableEventEndpoint;
+import com.nike.cerberus.endpoints.RiposteEndpoint;
 import com.nike.cerberus.error.DefaultApiError;
 import com.nike.cerberus.service.SecureDataService;
 import com.nike.cerberus.service.SecureDataVersionService;
@@ -49,6 +50,7 @@ import java.util.concurrent.Executor;
 import static com.nike.cerberus.endpoints.file.WriteSecureFile.BASE_PATH;
 import static javax.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM;
 
+@RiposteEndpoint
 public class ReadSecureFile extends AuditableEventEndpoint<Void, byte[]> {
 
     private final SecureDataService secureDataService;

--- a/src/main/java/com/nike/cerberus/endpoints/file/WriteSecureFile.java
+++ b/src/main/java/com/nike/cerberus/endpoints/file/WriteSecureFile.java
@@ -23,6 +23,7 @@ import com.nike.cerberus.SecureDataRequestService;
 import com.nike.cerberus.domain.SecureDataRequestInfo;
 import com.nike.cerberus.endpoints.AuditableEventEndpoint;
 import com.nike.cerberus.endpoints.CustomizableAuditData;
+import com.nike.cerberus.endpoints.RiposteEndpoint;
 import com.nike.cerberus.error.DefaultApiError;
 import com.nike.cerberus.service.SecureDataService;
 import com.nike.riposte.server.http.RequestInfo;
@@ -46,6 +47,7 @@ import java.util.stream.Collectors;
 /**
  * Creates a secure file.
  */
+@RiposteEndpoint
 public class WriteSecureFile extends AuditableEventEndpoint<Void, Void> {
 
     private final Logger log = LoggerFactory.getLogger(getClass());

--- a/src/main/java/com/nike/cerberus/endpoints/role/GetAllRoles.java
+++ b/src/main/java/com/nike/cerberus/endpoints/role/GetAllRoles.java
@@ -17,6 +17,7 @@
 package com.nike.cerberus.endpoints.role;
 
 import com.nike.cerberus.domain.Role;
+import com.nike.cerberus.endpoints.RiposteEndpoint;
 import com.nike.cerberus.service.RoleService;
 import com.nike.riposte.server.http.RequestInfo;
 import com.nike.riposte.server.http.ResponseInfo;
@@ -34,6 +35,7 @@ import java.util.concurrent.Executor;
 /**
  * Returns all known roles.
  */
+@RiposteEndpoint
 public class GetAllRoles extends StandardEndpoint<Void, List<Role>> {
 
     private final RoleService roleService;

--- a/src/main/java/com/nike/cerberus/endpoints/role/GetRole.java
+++ b/src/main/java/com/nike/cerberus/endpoints/role/GetRole.java
@@ -17,6 +17,7 @@
 package com.nike.cerberus.endpoints.role;
 
 import com.nike.cerberus.domain.Role;
+import com.nike.cerberus.endpoints.RiposteEndpoint;
 import com.nike.cerberus.service.RoleService;
 import com.nike.riposte.server.http.RequestInfo;
 import com.nike.riposte.server.http.ResponseInfo;
@@ -36,6 +37,7 @@ import java.util.concurrent.Executor;
 /**
  * Returns the role for the specified ID.
  */
+@RiposteEndpoint
 public class GetRole extends StandardEndpoint<Void, Role> {
 
     public static final String PATH_PARAM_ID = "id";

--- a/src/main/java/com/nike/cerberus/endpoints/sdb/CreateSafeDepositBoxV1.java
+++ b/src/main/java/com/nike/cerberus/endpoints/sdb/CreateSafeDepositBoxV1.java
@@ -21,6 +21,7 @@ import com.nike.backstopper.exception.ApiException;
 import com.nike.cerberus.domain.SafeDepositBoxV1;
 import com.nike.cerberus.endpoints.AuditableEventEndpoint;
 import com.nike.cerberus.endpoints.CustomizableAuditData;
+import com.nike.cerberus.endpoints.RiposteEndpoint;
 import com.nike.cerberus.error.DefaultApiError;
 import com.nike.cerberus.security.CmsRequestSecurityValidator;
 import com.nike.cerberus.security.CerberusPrincipal;
@@ -53,6 +54,7 @@ import static io.netty.handler.codec.http.HttpHeaders.Names.LOCATION;
  * Creates a new safe deposit box.  Returns the assigned unique identifier.
  */
 @Deprecated
+@RiposteEndpoint
 public class CreateSafeDepositBoxV1 extends AuditableEventEndpoint<SafeDepositBoxV1, Map<String, String>> {
 
     private final Logger log = LoggerFactory.getLogger(getClass());

--- a/src/main/java/com/nike/cerberus/endpoints/sdb/CreateSafeDepositBoxV2.java
+++ b/src/main/java/com/nike/cerberus/endpoints/sdb/CreateSafeDepositBoxV2.java
@@ -21,6 +21,7 @@ import com.nike.backstopper.exception.ApiException;
 import com.nike.cerberus.domain.SafeDepositBoxV2;
 import com.nike.cerberus.endpoints.AuditableEventEndpoint;
 import com.nike.cerberus.endpoints.CustomizableAuditData;
+import com.nike.cerberus.endpoints.RiposteEndpoint;
 import com.nike.cerberus.error.DefaultApiError;
 import com.nike.cerberus.security.CmsRequestSecurityValidator;
 import com.nike.cerberus.security.CerberusPrincipal;
@@ -50,6 +51,7 @@ import static io.netty.handler.codec.http.HttpHeaders.Names.LOCATION;
 /**
  * Creates a new safe deposit box.  Returns the assigned unique identifier.
  */
+@RiposteEndpoint
 public class CreateSafeDepositBoxV2 extends AuditableEventEndpoint<SafeDepositBoxV2, SafeDepositBoxV2> {
 
     private final Logger log = LoggerFactory.getLogger(getClass());

--- a/src/main/java/com/nike/cerberus/endpoints/sdb/DeleteSafeDepositBox.java
+++ b/src/main/java/com/nike/cerberus/endpoints/sdb/DeleteSafeDepositBox.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Sets;
 import com.nike.backstopper.exception.ApiException;
 import com.nike.cerberus.endpoints.AuditableEventEndpoint;
 import com.nike.cerberus.endpoints.CustomizableAuditData;
+import com.nike.cerberus.endpoints.RiposteEndpoint;
 import com.nike.cerberus.error.DefaultApiError;
 import com.nike.cerberus.security.CmsRequestSecurityValidator;
 import com.nike.cerberus.security.CerberusPrincipal;
@@ -48,6 +49,7 @@ import static com.nike.cerberus.CerberusHttpHeaders.HEADER_X_REFRESH_TOKEN;
 /**
  * Endpoint for deleting a safe deposit box.
  */
+@RiposteEndpoint
 public class DeleteSafeDepositBox extends AuditableEventEndpoint<Void, Void> {
 
     private final Logger log = LoggerFactory.getLogger(getClass());

--- a/src/main/java/com/nike/cerberus/endpoints/sdb/GetSafeDepositBoxV1.java
+++ b/src/main/java/com/nike/cerberus/endpoints/sdb/GetSafeDepositBoxV1.java
@@ -20,6 +20,7 @@ import com.nike.backstopper.exception.ApiException;
 import com.nike.cerberus.domain.SafeDepositBoxV1;
 import com.nike.cerberus.endpoints.AuditableEventEndpoint;
 import com.nike.cerberus.endpoints.CustomizableAuditData;
+import com.nike.cerberus.endpoints.RiposteEndpoint;
 import com.nike.cerberus.error.DefaultApiError;
 import com.nike.cerberus.security.CmsRequestSecurityValidator;
 import com.nike.cerberus.security.CerberusPrincipal;
@@ -45,6 +46,7 @@ import java.util.concurrent.Executor;
  * deposit box by its unique id.
  */
 @Deprecated
+@RiposteEndpoint
 public class GetSafeDepositBoxV1 extends AuditableEventEndpoint<Void, SafeDepositBoxV1> {
 
     private final Logger log = LoggerFactory.getLogger(getClass());

--- a/src/main/java/com/nike/cerberus/endpoints/sdb/GetSafeDepositBoxV2.java
+++ b/src/main/java/com/nike/cerberus/endpoints/sdb/GetSafeDepositBoxV2.java
@@ -21,6 +21,7 @@ import com.nike.backstopper.exception.ApiException;
 import com.nike.cerberus.domain.SafeDepositBoxV2;
 import com.nike.cerberus.endpoints.AuditableEventEndpoint;
 import com.nike.cerberus.endpoints.CustomizableAuditData;
+import com.nike.cerberus.endpoints.RiposteEndpoint;
 import com.nike.cerberus.error.DefaultApiError;
 import com.nike.cerberus.security.CmsRequestSecurityValidator;
 import com.nike.cerberus.security.CerberusPrincipal;
@@ -45,6 +46,7 @@ import java.util.concurrent.Executor;
  * Extracts the user groups from the security context for the request and attempts to get details about the safe
  * deposit box by its unique id.
  */
+@RiposteEndpoint
 public class GetSafeDepositBoxV2 extends AuditableEventEndpoint<Void, SafeDepositBoxV2> {
 
     private final Logger log = LoggerFactory.getLogger(getClass());

--- a/src/main/java/com/nike/cerberus/endpoints/sdb/GetSafeDepositBoxes.java
+++ b/src/main/java/com/nike/cerberus/endpoints/sdb/GetSafeDepositBoxes.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Sets;
 import com.nike.backstopper.exception.ApiException;
 import com.nike.cerberus.domain.SafeDepositBoxSummary;
 import com.nike.cerberus.endpoints.AuditableEventEndpoint;
+import com.nike.cerberus.endpoints.RiposteEndpoint;
 import com.nike.cerberus.error.DefaultApiError;
 import com.nike.cerberus.security.CmsRequestSecurityValidator;
 import com.nike.cerberus.security.CerberusPrincipal;
@@ -45,6 +46,7 @@ import java.util.concurrent.Executor;
  * Extracts the user groups from the security context for the request and returns any safe deposit boxes
  * associated with that list of user groups.
  */
+@RiposteEndpoint
 public class GetSafeDepositBoxes extends AuditableEventEndpoint<Void, List<SafeDepositBoxSummary>> {
 
     private final Logger log = LoggerFactory.getLogger(getClass());

--- a/src/main/java/com/nike/cerberus/endpoints/sdb/UpdateSafeDepositBoxV1.java
+++ b/src/main/java/com/nike/cerberus/endpoints/sdb/UpdateSafeDepositBoxV1.java
@@ -20,6 +20,7 @@ import com.nike.backstopper.exception.ApiException;
 import com.nike.cerberus.domain.SafeDepositBoxV1;
 import com.nike.cerberus.endpoints.AuditableEventEndpoint;
 import com.nike.cerberus.endpoints.CustomizableAuditData;
+import com.nike.cerberus.endpoints.RiposteEndpoint;
 import com.nike.cerberus.error.DefaultApiError;
 import com.nike.cerberus.security.CmsRequestSecurityValidator;
 import com.nike.cerberus.security.CerberusPrincipal;
@@ -49,6 +50,7 @@ import static com.nike.cerberus.CerberusHttpHeaders.HEADER_X_REFRESH_TOKEN;
  * Endpoint for updating a safe deposit box.
  */
 @Deprecated
+@RiposteEndpoint
 public class UpdateSafeDepositBoxV1 extends AuditableEventEndpoint<SafeDepositBoxV1, Void> {
 
     private final Logger log = LoggerFactory.getLogger(getClass());

--- a/src/main/java/com/nike/cerberus/endpoints/sdb/UpdateSafeDepositBoxV2.java
+++ b/src/main/java/com/nike/cerberus/endpoints/sdb/UpdateSafeDepositBoxV2.java
@@ -21,6 +21,7 @@ import com.nike.backstopper.exception.ApiException;
 import com.nike.cerberus.domain.SafeDepositBoxV2;
 import com.nike.cerberus.endpoints.AuditableEventEndpoint;
 import com.nike.cerberus.endpoints.CustomizableAuditData;
+import com.nike.cerberus.endpoints.RiposteEndpoint;
 import com.nike.cerberus.error.DefaultApiError;
 import com.nike.cerberus.security.CmsRequestSecurityValidator;
 import com.nike.cerberus.security.CerberusPrincipal;
@@ -49,6 +50,7 @@ import static com.nike.cerberus.CerberusHttpHeaders.HEADER_X_REFRESH_TOKEN;
 /**
  * Endpoint for updating a safe deposit box.
  */
+@RiposteEndpoint
 public class UpdateSafeDepositBoxV2 extends AuditableEventEndpoint<SafeDepositBoxV2, SafeDepositBoxV2> {
 
     private final Logger log = LoggerFactory.getLogger(getClass());

--- a/src/main/java/com/nike/cerberus/endpoints/secret/DeleteSecureData.java
+++ b/src/main/java/com/nike/cerberus/endpoints/secret/DeleteSecureData.java
@@ -21,6 +21,7 @@ import com.nike.cerberus.SecureDataRequestService;
 import com.nike.cerberus.domain.SecureDataRequestInfo;
 import com.nike.cerberus.domain.SecureDataType;
 import com.nike.cerberus.domain.VaultStyleErrorResponse;
+import com.nike.cerberus.endpoints.RiposteEndpoint;
 import com.nike.cerberus.security.CerberusPrincipal;
 import com.nike.cerberus.service.PermissionsService;
 import com.nike.cerberus.service.SafeDepositBoxService;
@@ -39,6 +40,7 @@ import javax.inject.Inject;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
+@RiposteEndpoint
 public class DeleteSecureData extends SecureDataEndpointV1<Void, Object> {
 
     @Inject

--- a/src/main/java/com/nike/cerberus/endpoints/secret/ReadSecureData.java
+++ b/src/main/java/com/nike/cerberus/endpoints/secret/ReadSecureData.java
@@ -25,6 +25,7 @@ import com.nike.cerberus.domain.SecureDataRequestInfo;
 import com.nike.cerberus.domain.SecureDataResponse;
 import com.nike.cerberus.domain.SecureDataVersion;
 import com.nike.cerberus.domain.VaultStyleErrorResponse;
+import com.nike.cerberus.endpoints.RiposteEndpoint;
 import com.nike.cerberus.service.PermissionsService;
 import com.nike.cerberus.service.SafeDepositBoxService;
 import com.nike.cerberus.service.SecureDataService;
@@ -49,6 +50,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
+@RiposteEndpoint
 public class ReadSecureData extends SecureDataEndpointV1<Void, Object> {
 
 

--- a/src/main/java/com/nike/cerberus/endpoints/secret/WriteSecureData.java
+++ b/src/main/java/com/nike/cerberus/endpoints/secret/WriteSecureData.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Sets;
 import com.nike.cerberus.SecureDataRequestService;
 import com.nike.cerberus.domain.SecureDataRequestInfo;
 import com.nike.cerberus.domain.VaultStyleErrorResponse;
+import com.nike.cerberus.endpoints.RiposteEndpoint;
 import com.nike.cerberus.security.CerberusPrincipal;
 import com.nike.cerberus.service.PermissionsService;
 import com.nike.cerberus.service.SafeDepositBoxService;
@@ -40,6 +41,7 @@ import javax.inject.Inject;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
+@RiposteEndpoint
 public class WriteSecureData extends SecureDataEndpointV1<Object, Object> {
 
     private final Logger log = LoggerFactory.getLogger(getClass());

--- a/src/main/java/com/nike/cerberus/endpoints/version/GetSecretVersionPathsForSdb.java
+++ b/src/main/java/com/nike/cerberus/endpoints/version/GetSecretVersionPathsForSdb.java
@@ -20,6 +20,7 @@ package com.nike.cerberus.endpoints.version;
 import com.nike.backstopper.exception.ApiException;
 import com.nike.cerberus.endpoints.AuditableEventEndpoint;
 import com.nike.cerberus.endpoints.CustomizableAuditData;
+import com.nike.cerberus.endpoints.RiposteEndpoint;
 import com.nike.cerberus.error.DefaultApiError;
 import com.nike.cerberus.event.AuditableEvent;
 import com.nike.cerberus.security.CerberusPrincipal;
@@ -47,6 +48,7 @@ import java.util.concurrent.Executor;
  * Extracts the user groups from the security context for the request and returns any safe deposit boxes
  * associated with that list of user groups.
  */
+@RiposteEndpoint
 public class GetSecretVersionPathsForSdb extends AuditableEventEndpoint<Void, Set<String>> {
 
     private final Logger log = LoggerFactory.getLogger(getClass());

--- a/src/main/java/com/nike/cerberus/endpoints/version/GetSecureDataVersions.java
+++ b/src/main/java/com/nike/cerberus/endpoints/version/GetSecureDataVersions.java
@@ -23,6 +23,7 @@ import com.nike.cerberus.domain.SecureDataRequestInfo;
 import com.nike.cerberus.domain.SecureDataVersionsResult;
 import com.nike.cerberus.endpoints.AuditableEventEndpoint;
 import com.nike.cerberus.endpoints.CustomizableAuditData;
+import com.nike.cerberus.endpoints.RiposteEndpoint;
 import com.nike.cerberus.error.DefaultApiError;
 import com.nike.cerberus.event.AuditableEvent;
 import com.nike.cerberus.service.PaginationService;
@@ -44,6 +45,7 @@ import java.util.concurrent.Executor;
  * Extracts the user groups from the security context for the request and returns any safe deposit boxes
  * associated with that list of user groups.
  */
+@RiposteEndpoint
 public class GetSecureDataVersions extends AuditableEventEndpoint<Void, SecureDataVersionsResult> {
 
     private final Logger log = LoggerFactory.getLogger(getClass());

--- a/src/main/java/com/nike/cerberus/server/config/guice/CmsGuiceModule.java
+++ b/src/main/java/com/nike/cerberus/server/config/guice/CmsGuiceModule.java
@@ -18,45 +18,14 @@
 package com.nike.cerberus.server.config.guice;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.inject.AbstractModule;
-import com.google.inject.Injector;
-import com.google.inject.Key;
-import com.google.inject.Provides;
+import com.google.inject.*;
 import com.google.inject.name.Names;
 import com.nike.backstopper.apierror.projectspecificinfo.ProjectApiErrors;
 import com.nike.cerberus.auth.connector.AuthConnector;
 import com.nike.cerberus.aws.KmsClientFactory;
-import com.nike.cerberus.endpoints.GetDashboard;
-import com.nike.cerberus.endpoints.GetDashboardRedirect;
-import com.nike.cerberus.endpoints.HealthCheckEndpoint;
-import com.nike.cerberus.endpoints.RobotsEndpoint;
-import com.nike.cerberus.endpoints.admin.*;
+import com.nike.cerberus.endpoints.*;
 import com.nike.cerberus.endpoints.authentication.*;
 import com.nike.cerberus.endpoints.authentication.CodeHandlingMfaCheck;
-import com.nike.cerberus.endpoints.category.CreateCategory;
-import com.nike.cerberus.endpoints.category.DeleteCategory;
-import com.nike.cerberus.endpoints.category.GetAllCategories;
-import com.nike.cerberus.endpoints.category.GetCategory;
-import com.nike.cerberus.endpoints.role.GetAllRoles;
-import com.nike.cerberus.endpoints.role.GetRole;
-import com.nike.cerberus.endpoints.sdb.CreateSafeDepositBoxV1;
-import com.nike.cerberus.endpoints.sdb.CreateSafeDepositBoxV2;
-import com.nike.cerberus.endpoints.sdb.DeleteSafeDepositBox;
-import com.nike.cerberus.endpoints.sdb.GetSafeDepositBoxV1;
-import com.nike.cerberus.endpoints.sdb.GetSafeDepositBoxV2;
-import com.nike.cerberus.endpoints.sdb.GetSafeDepositBoxes;
-import com.nike.cerberus.endpoints.sdb.UpdateSafeDepositBoxV1;
-import com.nike.cerberus.endpoints.sdb.UpdateSafeDepositBoxV2;
-import com.nike.cerberus.endpoints.secret.DeleteSecureData;
-import com.nike.cerberus.endpoints.file.DeleteSecureFile;
-import com.nike.cerberus.endpoints.file.HeadSecureFile;
-import com.nike.cerberus.endpoints.file.GetSecureFiles;
-import com.nike.cerberus.endpoints.secret.ReadSecureData;
-import com.nike.cerberus.endpoints.file.ReadSecureFile;
-import com.nike.cerberus.endpoints.secret.WriteSecureData;
-import com.nike.cerberus.endpoints.file.WriteSecureFile;
-import com.nike.cerberus.endpoints.version.GetSecretVersionPathsForSdb;
-import com.nike.cerberus.endpoints.version.GetSecureDataVersions;
 import com.nike.cerberus.error.DefaultApiErrorsImpl;
 import com.nike.cerberus.event.processor.EventProcessor;
 import com.nike.cerberus.hystrix.HystrixKmsClientFactory;
@@ -76,6 +45,7 @@ import io.netty.handler.ssl.util.SelfSignedCertificate;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.Validate;
+import org.reflections.Reflections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -87,11 +57,7 @@ import javax.validation.Validator;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.security.cert.CertificateException;
-import java.util.Arrays;
-import java.util.LinkedHashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -164,68 +130,12 @@ public class CmsGuiceModule extends AbstractModule {
     @Provides
     @Singleton
     @Named("appEndpoints")
-    public Set<Endpoint<?>> appEndpoints(
-            HealthCheckEndpoint healthCheckEndpoint,
-            RobotsEndpoint robotsEndpoint,
-            // Cerberus endpoints
-            GetAllCategories getAllCategories,
-            GetCategory getCategory,
-            CreateCategory createCategory,
-            DeleteCategory deleteCategory,
-            AuthenticateUser authenticateUser,
-            CodeHandlingMfaCheck mfaCheck,
-            RefreshUserToken refreshUserToken,
-            AuthenticateIamRole authenticateIamRole,
-            AuthenticateIamPrincipal authenticateIamPrincipal,
-            AuthenticateStsIdentity authenticateStsIdentity,
-            RevokeToken revokeToken,
-            GetAllRoles getAllRoles,
-            GetRole getRole,
-            GetSafeDepositBoxes getSafeDepositBoxes,
-            GetSafeDepositBoxV1 getSafeDepositBoxV1,
-            GetSafeDepositBoxV2 getSafeDepositBoxV2,
-            DeleteSafeDepositBox deleteSafeDepositBox,
-            UpdateSafeDepositBoxV1 updateSafeDepositBoxV1,
-            UpdateSafeDepositBoxV2 updateSafeDepositBoxV2,
-            CreateSafeDepositBoxV1 createSafeDepositBoxV1,
-            CreateSafeDepositBoxV2 createSafeDepositBoxV2,
-            GetSDBMetadata getSDBMetadata,
-            OverrideSdbOwner overrideSdbOwner,
-            PutSDBMetadata putSDBMetadata,
-            GetDashboardRedirect getDashboardRedirect,
-            GetDashboard getDashboard,
-            WriteSecureData writeSecureData,
-            ReadSecureData readSecureData,
-            DeleteSecureData deleteSecureData,
-            TriggerScheduledJob triggerScheduledJob,
-            RestoreSafeDepositBox restoreSafeDepositBox,
-            GetSecretVersionPathsForSdb getSecretVersionPathsForSdb,
-            GetSecureDataVersions getSecureDataVersions,
-            WriteSecureFile writeSecureFile,
-            ReadSecureFile readSecureFile,
-            HeadSecureFile headSecureFile,
-            GetSecureFiles getSecureFiles,
-            DeleteSecureFile deleteSecureFile,
-            GetAuthKmsKeyMetadata getAuthKmsKeyMetadata
-    ) {
-        return new LinkedHashSet<>(Arrays.<Endpoint<?>>asList(
-                healthCheckEndpoint,
-                robotsEndpoint,
-                // Cerberus endpoints
-                getAllCategories, getCategory, createCategory, deleteCategory,
-                authenticateUser, authenticateIamPrincipal, authenticateStsIdentity, mfaCheck, refreshUserToken,
-                authenticateIamRole, revokeToken,
-                getAllRoles, getRole,
-                getSafeDepositBoxes, getSafeDepositBoxV1, getSafeDepositBoxV2,
-                deleteSafeDepositBox, updateSafeDepositBoxV1, updateSafeDepositBoxV2, createSafeDepositBoxV1, createSafeDepositBoxV2,
-                getSDBMetadata, putSDBMetadata, overrideSdbOwner,
-                writeSecureData, readSecureData, deleteSecureData,
-                triggerScheduledJob,
-                getDashboard, getDashboardRedirect,
-                writeSecureFile, readSecureFile, deleteSecureFile, headSecureFile, getSecureFiles,
-                restoreSafeDepositBox,
-                getSecretVersionPathsForSdb, getSecureDataVersions, getAuthKmsKeyMetadata
-        ));
+    public Set<Endpoint<?>> appEndpoints(Injector injector) {
+        Reflections packageReflections = new Reflections("com.nike.cerberus");
+        Set<Class<?>> riposteEndpoints = packageReflections.getTypesAnnotatedWith(RiposteEndpoint.class);
+        Set<Endpoint<?>> endpoints = new HashSet<>();
+        riposteEndpoints.forEach(c -> endpoints.add((Endpoint) injector.getInstance(c)));
+        return endpoints;
     }
 
     @Provides


### PR DESCRIPTION
I am doing a POC to Springify our Riposte plus Guice setup so that we can eventually layer in Nike specific code via internal modules that get loaded via class path scanning.