### PR TITLE
fix: dashboard height should take up full screen

### DIFF
--- a/dashboard/app/components/App/App.scss
+++ b/dashboard/app/components/App/App.scss
@@ -2,6 +2,7 @@
 
 html, body {
   height: 100%;
+  overflow-y: hidden;
 }
 
 #main-wrapper {
@@ -32,7 +33,7 @@ html, body {
   border-left-style: solid;
   border-left-width: 1px;
 
-  max-height: 800px;
+  max-height: 90vh;
   overflow-y: auto;
 
   #workspace-wrapper {

--- a/dashboard/app/components/SideBar/SideBar.scss
+++ b/dashboard/app/components/SideBar/SideBar.scss
@@ -7,7 +7,7 @@
   display: flex;
   flex-flow: column;
 
-  max-height: 800px;
+  max-height: 90vh;
   overflow-y: auto;
 
   .sidebar-header {

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,6 +14,6 @@
 # limitations under the License.
 #
 
-version=3.30.0
+version=3.31.1
 groupId=com.nike.cerberus
 artifactId=cms


### PR DESCRIPTION
Hides overflow-y on body so double scrollbar does not appear.

![Screen Shot 2019-09-13 at 1 25 50 PM](https://user-images.githubusercontent.com/3334263/65186431-895da300-da1e-11e9-8e99-65228058ba20.png)
![Screen Shot 2019-09-18 at 2 14 19 PM](https://user-images.githubusercontent.com/3334263/65186500-a2feea80-da1e-11e9-9cd9-f9d87bdbfd18.png)
